### PR TITLE
RecordingError renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## Next Release
+
+- [#2](https://github.com/groue/CombineExpectations/pull/2): RecordingError renaming
+
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ func testSingleError() throws {
     let element = try wait(for: recorder.single, timeout: 1)
 }
     
-// FAIL: Caught error RecordingError.moreThanOneElement
+// FAIL: Caught error RecordingError.tooManyElements
 func testSingleMoreThanOneElementError() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
@@ -595,7 +595,7 @@ func testSingleMoreThanOneElementError() throws {
     let element = try wait(for: recorder.single, timeout: 1)
 }
     
-// FAIL: Caught error RecordingError.noElements
+// FAIL: Caught error RecordingError.notEnoughElements
 func testSingleNoElementsError() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -411,10 +411,10 @@ extension Recorder {
     public var single: PublisherExpectations.Single<Input, Failure> {
         elements.map { elements in
             guard let element = elements.first else {
-                throw RecordingError.noElements
+                throw RecordingError.notEnoughElements(minimumExpected: 1)
             }
             if elements.count > 1 {
-                throw RecordingError.moreThanOneElement
+                throw RecordingError.tooManyElements(maximumExpected: 1)
             }
             return element
         }

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -411,10 +411,10 @@ extension Recorder {
     public var single: PublisherExpectations.Single<Input, Failure> {
         elements.map { elements in
             guard let element = elements.first else {
-                throw RecordingError.notEnoughElements(minimumExpected: 1)
+                throw RecordingError.notEnoughElements
             }
             if elements.count > 1 {
-                throw RecordingError.tooManyElements(maximumExpected: 1)
+                throw RecordingError.tooManyElements
             }
             return element
         }

--- a/Sources/CombineExpectations/RecordingError.swift
+++ b/Sources/CombineExpectations/RecordingError.swift
@@ -2,16 +2,16 @@ import Foundation
 
 /// An error that may be thrown when waiting for publisher expectations.
 public enum RecordingError: Error {
-    /// Can be thrown when the publisher does not complete in time.
+    /// The publisher did not complete.
     case notCompleted
     
-    /// Can be thrown when waiting for `recorder.single`, when the publisher
-    /// does not publish any element.
-    case noElements
+    /// The publisher did not publish enough elements.
+    /// For example, see `recorder.single`.
+    case notEnoughElements(minimumExpected: Int)
     
-    /// Can be thrown when waiting for `recorder.single`, when the publisher
-    /// publishes more than one element.
-    case moreThanOneElement
+    /// The publisher did publish too many elements.
+    /// For example, see `recorder.single`.
+    case tooManyElements(maximumExpected: Int)
 }
 
 extension RecordingError: LocalizedError {
@@ -19,10 +19,10 @@ extension RecordingError: LocalizedError {
         switch self {
         case .notCompleted:
             return "RecordingError.notCompleted"
-        case .noElements:
-            return "RecordingError.noElements"
-        case .moreThanOneElement:
-            return "RecordingError.moreThanOneElement"
+        case let .notEnoughElements(minimumExpected):
+            return "RecordingError.notEnoughElements(minimumExpected:\(minimumExpected))"
+        case let .tooManyElements(maximumExpected):
+            return "RecordingError.tooManyElements(maximumExpected:\(maximumExpected))"
         }
     }
 }

--- a/Sources/CombineExpectations/RecordingError.swift
+++ b/Sources/CombineExpectations/RecordingError.swift
@@ -7,11 +7,11 @@ public enum RecordingError: Error {
     
     /// The publisher did not publish enough elements.
     /// For example, see `recorder.single`.
-    case notEnoughElements(minimumExpected: Int)
+    case notEnoughElements
     
     /// The publisher did publish too many elements.
     /// For example, see `recorder.single`.
-    case tooManyElements(maximumExpected: Int)
+    case tooManyElements
 }
 
 extension RecordingError: LocalizedError {
@@ -19,10 +19,10 @@ extension RecordingError: LocalizedError {
         switch self {
         case .notCompleted:
             return "RecordingError.notCompleted"
-        case let .notEnoughElements(minimumExpected):
-            return "RecordingError.notEnoughElements(minimumExpected:\(minimumExpected))"
-        case let .tooManyElements(maximumExpected):
-            return "RecordingError.tooManyElements(maximumExpected:\(maximumExpected))"
+        case .notEnoughElements:
+            return "RecordingError.notEnoughElements"
+        case .tooManyElements:
+            return "RecordingError.tooManyElements"
         }
     }
 }

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -337,7 +337,7 @@ class DocumentationTests: FailureTestCase {
         } catch is MyError { }
     }
     
-    // FAIL: Caught error RecordingError.moreThanOneElement
+    // FAIL: Caught error RecordingError.tooManyElements
     func testSingleMoreThanOneElementError() throws {
         do {
             let publisher = PassthroughSubject<String, Never>()
@@ -346,16 +346,16 @@ class DocumentationTests: FailureTestCase {
             publisher.send("bar")
             publisher.send(completion: .finished)
             _ = try wait(for: recorder.single, timeout: 0.1)
-        } catch RecordingError.moreThanOneElement { }
+        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
     }
     
-    // FAIL: Caught error RecordingError.noElements
+    // FAIL: Caught error RecordingError.notEnoughElements
     func testSingleNoElementsError() throws {
         do {
             let publisher = PassthroughSubject<String, Never>()
             let recorder = publisher.record()
             publisher.send(completion: .finished)
             _ = try wait(for: recorder.single, timeout: 0.1)
-        } catch RecordingError.noElements { }
+        } catch RecordingError.notEnoughElements(minimumExpected: 1) { }
     }
 }

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -346,7 +346,7 @@ class DocumentationTests: FailureTestCase {
             publisher.send("bar")
             publisher.send(completion: .finished)
             _ = try wait(for: recorder.single, timeout: 0.1)
-        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
+        } catch RecordingError.tooManyElements { }
     }
     
     // FAIL: Caught error RecordingError.notEnoughElements
@@ -356,6 +356,6 @@ class DocumentationTests: FailureTestCase {
             let recorder = publisher.record()
             publisher.send(completion: .finished)
             _ = try wait(for: recorder.single, timeout: 0.1)
-        } catch RecordingError.notEnoughElements(minimumExpected: 1) { }
+        } catch RecordingError.notEnoughElements { }
     }
 }

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -283,7 +283,7 @@ class RecorderTests: XCTestCase {
         do {
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.moreThanOneElement { }
+        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
         
         do {
             try wait(for: recorder.finished, timeout: 1)
@@ -836,7 +836,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.noElements { }
+        } catch RecordingError.notEnoughElements(minimumExpected: 1) { }
         do {
             let publisher = (0..<1).publisher
             let recorder = publisher.record()
@@ -848,7 +848,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.moreThanOneElement { }
+        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
     }
     
     func testWaitForSingleAsync() throws {
@@ -857,7 +857,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.noElements { }
+        } catch RecordingError.notEnoughElements(minimumExpected: 1) { }
         do {
             let publisher = (0..<1).publisher.receive(on: DispatchQueue.main)
             let recorder = publisher.record()
@@ -869,7 +869,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.moreThanOneElement { }
+        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
     }
     
     func testWaitForSingleFailure() throws {

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -283,7 +283,7 @@ class RecorderTests: XCTestCase {
         do {
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
+        } catch RecordingError.tooManyElements { }
         
         do {
             try wait(for: recorder.finished, timeout: 1)
@@ -836,7 +836,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.notEnoughElements(minimumExpected: 1) { }
+        } catch RecordingError.notEnoughElements { }
         do {
             let publisher = (0..<1).publisher
             let recorder = publisher.record()
@@ -848,7 +848,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
+        } catch RecordingError.tooManyElements { }
     }
     
     func testWaitForSingleAsync() throws {
@@ -857,7 +857,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.notEnoughElements(minimumExpected: 1) { }
+        } catch RecordingError.notEnoughElements { }
         do {
             let publisher = (0..<1).publisher.receive(on: DispatchQueue.main)
             let recorder = publisher.record()
@@ -869,7 +869,7 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             _ = try wait(for: recorder.single, timeout: 1)
             XCTFail("Expected RecordingError")
-        } catch RecordingError.tooManyElements(maximumExpected: 1) { }
+        } catch RecordingError.tooManyElements { }
     }
     
     func testWaitForSingleFailure() throws {


### PR DESCRIPTION
```diff
 public enum RecordingError: Error {
     case notCompleted
-    case noElements
+    case notEnoughElements
-    case moreThanOneElement
+    case tooManyElements
 }
```

This should let us reuse the same errors for more expectations.