### PR TITLE
Next Expectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ## Next Release
 
 - [#2](https://github.com/groue/CombineExpectations/pull/2): RecordingError renaming
+- [#2](https://github.com/groue/CombineExpectations/pull/3): Next Expectation
 
 
 ## 0.2.0

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ class PublisherTests: XCTestCase {
         // Wait for first element
         _ = try wait(for: recorder.first, timeout: ...)
         
-        // Wait for second element
-        _ = try wait(for: recorder.prefix(2), timeout: ...)
+        // Wait for next element
+        _ = try wait(for: recorder.next(), timeout: ...)
         
         // Wait for successful completion
         try wait(for: recorder.finished, timeout: ...)

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ func testPassthroughSubjectDoesNotPublishAnyElement() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Fulfilled inverted expectation
 func testInvertedFirstTooEarly() throws {
     let publisher = PassthroughSubject<String, Never>()
@@ -389,7 +389,7 @@ func testArrayPublisherPublishesLastElementLast() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Asynchronous wait failed
 // FAIL: Caught error RecordingError.notCompleted
 func testLastTimeout() throws {
@@ -441,7 +441,7 @@ func testArrayOfTwoElementsPublishesElementsInOrder() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Asynchronous wait failed
 // FAIL: Caught error RecordingError.notEnoughElements
 func testNextTimeout() throws {
@@ -464,6 +464,41 @@ func testNextNotEnoughElementsError() throws {
     let recorder = publisher.record()
     publisher.send(completion: .finished)
     let element = try wait(for: recorder.next(), timeout: 1)
+}
+```
+
+</details>
+
+This publisher expectation can be [inverted]:
+
+```swift
+// SUCCESS: no timeout, no error
+func testPassthroughSubjectDoesNotPublishAnyElement() throws {
+    let publisher = PassthroughSubject<String, Never>()
+    let recorder = publisher.record()
+    try wait(for: recorder.next().inverted, timeout: 1)
+}
+```
+
+<details>
+    <summary>Examples of failing tests</summary>
+
+```swift
+// FAIL: Fulfilled inverted expectation
+func testInvertedNextTooEarly() throws {
+    let publisher = PassthroughSubject<String, Never>()
+    let recorder = publisher.record()
+    publisher.send("foo")
+    try wait(for: recorder.next().inverted, timeout: 0.1)
+}
+
+// FAIL: Fulfilled inverted expectation
+// FAIL: Caught error MyError
+func testInvertedNextError() throws {
+    let publisher = PassthroughSubject<String, MyError>()
+    let recorder = publisher.record()
+    publisher.send(completion: .failure(MyError()))
+    try wait(for: recorder.next().inverted, timeout: 0.1)
 }
 ```
 
@@ -501,7 +536,7 @@ func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Asynchronous wait failed
 // FAIL: Caught error RecordingError.notEnoughElements
 func testNextCountTimeout() throws {
@@ -560,7 +595,7 @@ func testArrayOfThreeElementsPublishesTwoFirstElementsWithoutError() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Asynchronous wait failed
 func testPrefixTimeout() throws {
     let publisher = PassthroughSubject<String, Never>()
@@ -653,7 +688,7 @@ func testArrayPublisherRecording() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Asynchronous wait failed
 // FAIL: Caught error RecordingError.notCompleted
 func testRecordingTimeout() throws {
@@ -693,7 +728,7 @@ func testJustPublishesExactlyOneElement() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift    
+```swift
 // FAIL: Asynchronous wait failed
 // FAIL: Caught error RecordingError.notCompleted
 func testSingleTimeout() throws {

--- a/README.md
+++ b/README.md
@@ -438,6 +438,37 @@ func testArrayOfTwoElementsPublishesElementsInOrder() throws {
 }
 ```
 
+<details>
+    <summary>Examples of failing tests</summary>
+
+```swift    
+// FAIL: Asynchronous wait failed
+// FAIL: Caught error RecordingError.notEnoughElements
+func testNextTimeout() throws {
+    let publisher = PassthroughSubject<String, Never>()
+    let recorder = publisher.record()
+    let element = try wait(for: recorder.next(), timeout: 0.1)
+}
+
+// FAIL: Caught error MyError
+func testNextError() throws {
+    let publisher = PassthroughSubject<String, MyError>()
+    let recorder = publisher.record()
+    publisher.send(completion: .failure(MyError()))
+    let element = try wait(for: recorder.next(), timeout: 0.1)
+}
+
+// FAIL: Caught error RecordingError.notEnoughElements
+func testNextNotEnoughElementsError() throws {
+    let publisher = PassthroughSubject<String, Never>()
+    let recorder = publisher.record()
+    publisher.send(completion: .finished)
+    let element = try wait(for: recorder.next(), timeout: 0.1)
+}
+```
+
+</details>
+
 
 ---
 
@@ -646,7 +677,7 @@ func testSingleError() throws {
 }
     
 // FAIL: Caught error RecordingError.tooManyElements
-func testSingleMoreThanOneElementError() throws {
+func testSingleTooManyElementsError() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
     publisher.send("foo")
@@ -656,7 +687,7 @@ func testSingleMoreThanOneElementError() throws {
 }
     
 // FAIL: Caught error RecordingError.notEnoughElements
-func testSingleNoElementsError() throws {
+func testSingleNotEnoughElementsError() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
     publisher.send(completion: .finished)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ There are various publisher expectations. Each one waits for a specific publishe
 - [prefix(maxLength)]: the first N published elements
 - [recording]: the full recording of publisher events
 - [single]: the one and only published element
-- [Inverted Expectations]
 
 ---
 
@@ -246,7 +245,7 @@ func testFinishedError() throws {
 
 </details>
 
-This publisher expectation can be [inverted]:
+`recorder.finished` can be inverted:
 
 ```swift
 // SUCCESS: no timeout, no error
@@ -323,7 +322,7 @@ func testFirstError() throws {
 
 </details>
 
-This publisher expectation can be [inverted]:
+`recorder.first` can be inverted:
 
 ```swift
 // SUCCESS: no timeout, no error
@@ -469,7 +468,7 @@ func testNextNotEnoughElementsError() throws {
 
 </details>
 
-This publisher expectation can be [inverted]:
+`recorder.next()` can be inverted:
 
 ```swift
 // SUCCESS: no timeout, no error
@@ -616,7 +615,7 @@ func testPrefixError() throws {
 
 </details>
 
-This publisher expectation can be [inverted]:
+`recorder.prefix(maxLength)` can be inverted:
 
 ```swift
 // SUCCESS: no timeout, no error
@@ -767,25 +766,6 @@ func testSingleNotEnoughElementsError() throws {
 </details>
 
 
----
-
-### Inverted Expectations
-
-Some expectations can be inverted ([finished], [first], [prefix(maxLength)]). An inverted expectation fails if the base expectation fulfills within the specified timeout.
-
-When waiting for an inverted expectation, you receive the same result and eventual error as the base expectation.
-
-For example:
-
-```swift
-// SUCCESS: no timeout, no error
-func testPassthroughSubjectDoesNotFinish() throws {
-    let publisher = PassthroughSubject<String, Never>()
-    let recorder = publisher.record()
-    try wait(for: recorder.finished.inverted, timeout: 1)
-}
-```
-
 [Release Notes]: CHANGELOG.md
 [Usage]: #usage
 [Installation]: #installation
@@ -800,5 +780,3 @@ func testPassthroughSubjectDoesNotFinish() throws {
 [elements]: #elements
 [last]: #last
 [single]: #single
-[Inverted Expectations]: #inverted-expectations
-[inverted]: #inverted-expectations

--- a/README.md
+++ b/README.md
@@ -429,11 +429,11 @@ Example:
 func testArrayOfTwoElementsPublishesElementsInOrder() throws {
     let publisher = ["foo", "bar"].publisher
     let recorder = publisher.record()
-
+    
     var element = try wait(for: recorder.next(), timeout: 1)
     XCTAssertEqual(element, "foo")
-
-    var element = try wait(for: recorder.next(), timeout: 1)
+    
+    element = try wait(for: recorder.next(), timeout: 1)
     XCTAssertEqual(element, "bar")
 }
 ```

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ This publisher expectation can be [inverted]:
 func testPassthroughSubjectDoesNotPublishAnyElement() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
-    _ = try wait(for: recorder.first.inverted, timeout: 1)
+    try wait(for: recorder.first.inverted, timeout: 1)
 }
 ```
 
@@ -343,7 +343,7 @@ func testInvertedFirstTooEarly() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
     publisher.send("foo")
-    _ = try wait(for: recorder.first.inverted, timeout: 1)
+    try wait(for: recorder.first.inverted, timeout: 1)
 }
     
 // FAIL: Fulfilled inverted expectation
@@ -352,7 +352,7 @@ func testInvertedFirstError() throws {
     let publisher = PassthroughSubject<String, MyError>()
     let recorder = publisher.record()
     publisher.send(completion: .failure(MyError()))
-    _ = try wait(for: recorder.first.inverted, timeout: 1)
+    try wait(for: recorder.first.inverted, timeout: 1)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ There are various publisher expectations. Each one waits for a specific publishe
 - [finished]: the publisher successful completion
 - [first]: the first published element
 - [last]: the last published element
-- [next()]: the next published elements
+- [next()]: the next published element
 - [next(count)]: the next N published elements
 - [prefix(maxLength)]: the first N published elements
 - [recording]: the full recording of publisher events

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ func testArrayOfTwoElementsPublishesElementsInOrder() throws {
 func testNextTimeout() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
-    let element = try wait(for: recorder.next(), timeout: 0.1)
+    let element = try wait(for: recorder.next(), timeout: 1)
 }
 
 // FAIL: Caught error MyError
@@ -455,7 +455,7 @@ func testNextError() throws {
     let publisher = PassthroughSubject<String, MyError>()
     let recorder = publisher.record()
     publisher.send(completion: .failure(MyError()))
-    let element = try wait(for: recorder.next(), timeout: 0.1)
+    let element = try wait(for: recorder.next(), timeout: 1)
 }
 
 // FAIL: Caught error RecordingError.notEnoughElements
@@ -463,7 +463,7 @@ func testNextNotEnoughElementsError() throws {
     let publisher = PassthroughSubject<String, Never>()
     let recorder = publisher.record()
     publisher.send(completion: .finished)
-    let element = try wait(for: recorder.next(), timeout: 0.1)
+    let element = try wait(for: recorder.next(), timeout: 1)
 }
 ```
 
@@ -497,6 +497,40 @@ func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
     XCTAssertEqual(elements, ["baz"])
 }
 ```
+
+<details>
+    <summary>Examples of failing tests</summary>
+
+```swift    
+// FAIL: Asynchronous wait failed
+// FAIL: Caught error RecordingError.notEnoughElements
+func testNextCountTimeout() throws {
+    let publisher = PassthroughSubject<String, Never>()
+    let recorder = publisher.record()
+    publisher.send("foo")
+    let elements = try wait(for: recorder.next(2), timeout: 1)
+}
+
+// FAIL: Caught error MyError
+func testNextCountError() throws {
+    let publisher = PassthroughSubject<String, MyError>()
+    let recorder = publisher.record()
+    publisher.send("foo")
+    publisher.send(completion: .failure(MyError()))
+    let elements = try wait(for: recorder.next(2), timeout: 1)
+}
+
+// FAIL: Caught error RecordingError.notEnoughElements
+func testNextCountNotEnoughElementsError() throws {
+    let publisher = PassthroughSubject<String, Never>()
+    let recorder = publisher.record()
+    publisher.send("foo")
+    publisher.send(completion: .finished)
+    let elements = try wait(for: recorder.next(2), timeout: 1)
+}
+```
+
+</details>
 
 
 ---

--- a/Sources/CombineExpectations/PublisherExpectation.swift
+++ b/Sources/CombineExpectations/PublisherExpectation.swift
@@ -19,13 +19,11 @@ public enum PublisherExpectations { }
 public protocol PublisherExpectation {
     associatedtype Output
     
-    /// Implementation detail: don't use this method.
     /// :nodoc:
-    func _setup(_ expectation: XCTestExpectation)
+    func setup(_ expectation: XCTestExpectation)
     
-    /// Implementation detail: don't use this method.
     /// :nodoc:
-    func _value() throws -> Output
+    func expectedValue() throws -> Output
 }
 
 extension XCTestCase {
@@ -55,8 +53,8 @@ extension XCTestCase {
         throws -> R.Output
     {
         let expectation = self.expectation(description: description)
-        publisherExpectation._setup(expectation)
+        publisherExpectation.setup(expectation)
         wait(for: [expectation], timeout: timeout)
-        return try publisherExpectation._value()
+        return try publisherExpectation.expectedValue()
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Finished.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Finished.swift
@@ -43,11 +43,11 @@ extension PublisherExpectations {
     public struct Finished<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnCompletion(expectation)
         }
         
-        public func _value() throws {
+        public func expectedValue() throws {
             try recorder.expectationValue { (_, completion, remaining, consume) in
                 guard let completion = completion else {
                     consume(remaining.count)

--- a/Sources/CombineExpectations/PublisherExpectations/Finished.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Finished.swift
@@ -48,9 +48,9 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws {
-            try recorder.expectationValue { (_, completion, remaining, consume) in
+            try recorder.value { (_, completion, remainingElements, consume) in
                 guard let completion = completion else {
-                    consume(remaining.count)
+                    consume(remainingElements.count)
                     return
                 }
                 if case let .failure(error) = completion {

--- a/Sources/CombineExpectations/PublisherExpectations/Finished.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Finished.swift
@@ -17,11 +17,11 @@ import XCTest
 //      }
 
 extension PublisherExpectations {
-    /// A publisher expectation which waits for a publisher to
-    /// complete successfully.
+    /// A publisher expectation which waits for the recorded publisher
+    /// to complete.
     ///
-    /// When waiting for this expectation, an error is thrown if the publisher
-    /// fails with an error.
+    /// When waiting for this expectation, the publisher error is thrown if the
+    /// publisher fails.
     ///
     /// For example:
     ///
@@ -31,7 +31,16 @@ extension PublisherExpectations {
     ///         let recorder = publisher.record()
     ///         try wait(for: recorder.finished, timeout: 1)
     ///     }
-    public struct Finished<Input, Failure: Error>: InvertablePublisherExpectation {
+    ///
+    /// This publisher expectation can be inverted:
+    ///
+    ///     // SUCCESS: no timeout, no error
+    ///     func testPassthroughSubjectDoesNotFinish() throws {
+    ///         let publisher = PassthroughSubject<String, Never>()
+    ///         let recorder = publisher.record()
+    ///         try wait(for: recorder.finished.inverted, timeout: 1)
+    ///     }
+    public struct Finished<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
         public func _setup(_ expectation: XCTestExpectation) {
@@ -48,6 +57,24 @@ extension PublisherExpectations {
                     throw error
                 }
             }
+        }
+        
+        /// Returns an inverted publisher expectation which waits for a
+        /// publisher to complete successfully.
+        ///
+        /// When waiting for this expectation, an error is thrown if the
+        /// publisher fails with an error.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no timeout, no error
+        ///     func testPassthroughSubjectDoesNotFinish() throws {
+        ///         let publisher = PassthroughSubject<String, Never>()
+        ///         let recorder = publisher.record()
+        ///         try wait(for: recorder.finished.inverted, timeout: 1)
+        ///     }
+        public var inverted: Inverted<Self> {
+            return Inverted(base: self)
         }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Finished.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Finished.swift
@@ -39,11 +39,14 @@ extension PublisherExpectations {
         }
         
         public func _value() throws {
-            guard let completion = recorder.elementsAndCompletion.completion else {
-                return
-            }
-            if case let .failure(error) = completion {
-                throw error
+            try recorder.expectationValue { (_, completion, remaining, consume) in
+                guard let completion = completion else {
+                    consume(remaining.count)
+                    return
+                }
+                if case let .failure(error) = completion {
+                    throw error
+                }
             }
         }
     }

--- a/Sources/CombineExpectations/PublisherExpectations/First.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/First.swift
@@ -35,7 +35,7 @@ extension PublisherExpectations {
         let recorder: Recorder<Input, Failure>
         
         public func setup(_ expectation: XCTestExpectation) {
-            recorder.fulfillOnInput(expectation)
+            recorder.fulfillOnInput(expectation, includingConsumed: true)
         }
         
         public func expectedValue() throws -> Input? {
@@ -96,7 +96,7 @@ extension PublisherExpectations {
         
         public func setup(_ expectation: XCTestExpectation) {
             expectation.isInverted = true
-            recorder.fulfillOnInput(expectation)
+            recorder.fulfillOnInput(expectation, includingConsumed: true)
         }
         
         public func expectedValue() throws {

--- a/Sources/CombineExpectations/PublisherExpectations/First.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/First.swift
@@ -72,8 +72,8 @@ extension PublisherExpectations {
         ///         let elements = try wait(for: recorder.prefix(3).inverted, timeout: 1)
         ///         XCTAssertEqual(elements, ["foo", "bar"])
         ///     }
-        public var inverted: Inverted<Self> {
-            return Inverted(base: self)
+        public var inverted: FirstInverted<Input, Failure> {
+            return FirstInverted(recorder: recorder)
         }
     }
     

--- a/Sources/CombineExpectations/PublisherExpectations/First.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/First.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+extension PublisherExpectations {
+    /// A publisher expectation which waits for the recorded publisher to emit
+    /// one element, or to complete.
+    ///
+    /// When waiting for this expectation, the publisher error is thrown if the
+    /// publisher fails before publishing any element.
+    ///
+    /// Otherwise, the first published element is returned, or nil if the publisher
+    /// completes before it publishes any element.
+    ///
+    /// For example:
+    ///
+    ///     // SUCCESS: no timeout, no error
+    ///     func testArrayOfThreeElementsPublishesItsFirstElementWithoutError() throws {
+    ///         let publisher = ["foo", "bar", "baz"].publisher
+    ///         let recorder = publisher.record()
+    ///         if let element = try wait(for: recorder.first, timeout: 1) {
+    ///             XCTAssertEqual(element, "foo")
+    ///         } else {
+    ///             XCTFail("Expected one element")
+    ///         }
+    ///     }
+    ///
+    /// This publisher expectation can be inverted:
+    ///
+    ///     // SUCCESS: no timeout, no error
+    ///     func testPassthroughSubjectDoesNotPublishAnyElement() throws {
+    ///         let publisher = PassthroughSubject<String, Never>()
+    ///         let recorder = publisher.record()
+    ///         try wait(for: recorder.first.inverted, timeout: 1)
+    ///     }
+    public struct First<Input, Failure: Error>: PublisherExpectation {
+        let recorder: Recorder<Input, Failure>
+        
+        public func _setup(_ expectation: XCTestExpectation) {
+            recorder.fulfillOnInput(expectation)
+        }
+        
+        public func _value() throws -> Input? {
+            try recorder.expectationValue { (elements, completion, remaining, consume) in
+                if let first = elements.first {
+                    let extraCount = max(1 + remaining.count - elements.count, 0)
+                    consume(extraCount)
+                    return first
+                }
+                if case let .failure(error) = completion {
+                    throw error
+                }
+                return nil
+            }
+        }
+        
+        /// Returns an inverted publisher expectation which waits for a
+        /// publisher to emit `maxLength` elements, or to complete.
+        ///
+        /// When waiting for this expectation, the publisher error is thrown
+        /// if the publisher fails before `maxLength` elements are published.
+        ///
+        /// Otherwise, an array of received elements is returned, containing at
+        /// most `maxLength` elements, or less if the publisher completes early.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no timeout, no error
+        ///     func testPassthroughSubjectPublishesNoMoreThanSentValues() throws {
+        ///         let publisher = PassthroughSubject<String, Never>()
+        ///         let recorder = publisher.record()
+        ///         publisher.send("foo")
+        ///         publisher.send("bar")
+        ///         let elements = try wait(for: recorder.prefix(3).inverted, timeout: 1)
+        ///         XCTAssertEqual(elements, ["foo", "bar"])
+        ///     }
+        public var inverted: Inverted<Self> {
+            return Inverted(base: self)
+        }
+    }
+    
+    /// An inverted publisher expectation which waits for the recorded publisher
+    /// to emit one element, or to complete.
+    ///
+    /// When waiting for this expectation, the publisher error is thrown if the
+    /// publisher fails before publishing any element.
+    ///
+    /// For example:
+    ///
+    ///     // SUCCESS: no timeout, no error
+    ///     func testPassthroughSubjectDoesNotPublishAnyElement() throws {
+    ///         let publisher = PassthroughSubject<String, Never>()
+    ///         let recorder = publisher.record()
+    ///         try wait(for: recorder.first.inverted, timeout: 1)
+    ///     }
+    public struct FirstInverted<Input, Failure: Error>: PublisherExpectation {
+        let recorder: Recorder<Input, Failure>
+        
+        public func _setup(_ expectation: XCTestExpectation) {
+            expectation.isInverted = true
+            recorder.fulfillOnInput(expectation)
+        }
+        
+        public func _value() throws {
+            try recorder.expectationValue { (elements, completion, _, _) in
+                if elements.first == nil, case let .failure(error) = completion {
+                    throw error
+                }
+            }
+        }
+        
+        /// :nodoc:
+        public var inverted: First<Input, Failure> {
+            return First(recorder: recorder)
+        }
+    }
+}

--- a/Sources/CombineExpectations/PublisherExpectations/First.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/First.swift
@@ -106,10 +106,5 @@ extension PublisherExpectations {
                 }
             }
         }
-        
-        /// :nodoc:
-        public var inverted: First<Input, Failure> {
-            return First(recorder: recorder)
-        }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/First.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/First.swift
@@ -39,9 +39,9 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws -> Input? {
-            try recorder.expectationValue { (elements, completion, remaining, consume) in
+            try recorder.value { (elements, completion, remainingElements, consume) in
                 if let first = elements.first {
-                    let extraCount = max(1 + remaining.count - elements.count, 0)
+                    let extraCount = max(1 + remainingElements.count - elements.count, 0)
                     consume(extraCount)
                     return first
                 }
@@ -100,7 +100,7 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws {
-            try recorder.expectationValue { (elements, completion, _, _) in
+            try recorder.value { (elements, completion, _, _) in
                 if elements.first == nil, case let .failure(error) = completion {
                     throw error
                 }

--- a/Sources/CombineExpectations/PublisherExpectations/First.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/First.swift
@@ -34,11 +34,11 @@ extension PublisherExpectations {
     public struct First<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnInput(expectation)
         }
         
-        public func _value() throws -> Input? {
+        public func expectedValue() throws -> Input? {
             try recorder.expectationValue { (elements, completion, remaining, consume) in
                 if let first = elements.first {
                     let extraCount = max(1 + remaining.count - elements.count, 0)
@@ -94,12 +94,12 @@ extension PublisherExpectations {
     public struct FirstInverted<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             expectation.isInverted = true
             recorder.fulfillOnInput(expectation)
         }
         
-        public func _value() throws {
+        public func expectedValue() throws {
             try recorder.expectationValue { (elements, completion, _, _) in
                 if elements.first == nil, case let .failure(error) = completion {
                     throw error

--- a/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
@@ -1,8 +1,5 @@
 import XCTest
 
-/// The protocol for publisher expectations that can be inverted.
-public protocol InvertablePublisherExpectation: PublisherExpectation { }
-
 extension PublisherExpectations {
     /// A publisher expectation that fails if the base expectation is fulfilled.
     ///
@@ -17,7 +14,7 @@ extension PublisherExpectations {
     ///         let recorder = publisher.record()
     ///         try wait(for: recorder.finished.inverted, timeout: 1)
     ///     }
-    public struct Inverted<Base: PublisherExpectation>: InvertablePublisherExpectation {
+    public struct Inverted<Base: PublisherExpectation>: PublisherExpectation {
         let base: Base
         
         public func _setup(_ expectation: XCTestExpectation) {
@@ -28,25 +25,10 @@ extension PublisherExpectations {
         public func _value() throws -> Base.Output {
             try base._value()
         }
-    }
-}
-
-extension InvertablePublisherExpectation {
-    /// Returns an inverted expectation which fails if the base expectation
-    /// fulfills within the specified timeout.
-    ///
-    /// When waiting for an inverted expectation, you receive the same result
-    /// and eventual error as the base expectation.
-    ///
-    /// For example:
-    ///
-    ///     // SUCCESS: no timeout, no error
-    ///     func testPassthroughSubjectDoesNotFinish() throws {
-    ///         let publisher = PassthroughSubject<String, Never>()
-    ///         let recorder = publisher.record()
-    ///         try wait(for: recorder.finished.inverted, timeout: 1)
-    ///     }
-    public var inverted: PublisherExpectations.Inverted<Self> {
-        PublisherExpectations.Inverted(base: self)
+        
+        /// :nodoc:
+        var inverted: Base {
+            return base
+        }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
@@ -17,13 +17,13 @@ extension PublisherExpectations {
     public struct Inverted<Base: PublisherExpectation>: PublisherExpectation {
         let base: Base
         
-        public func _setup(_ expectation: XCTestExpectation) {
-            base._setup(expectation)
+        public func setup(_ expectation: XCTestExpectation) {
+            base.setup(expectation)
             expectation.isInverted.toggle()
         }
         
-        public func _value() throws -> Base.Output {
-            try base._value()
+        public func expectedValue() throws -> Base.Output {
+            try base.expectedValue()
         }
         
         /// :nodoc:

--- a/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
@@ -25,10 +25,5 @@ extension PublisherExpectations {
         public func expectedValue() throws -> Base.Output {
             try base.expectedValue()
         }
-        
-        /// :nodoc:
-        var inverted: Base {
-            return base
-        }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Map.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Map.swift
@@ -8,12 +8,12 @@ extension PublisherExpectations {
         let base: Base
         let transform: (Base.Output) throws -> Output
         
-        public func _setup(_ expectation: XCTestExpectation) {
-            base._setup(expectation)
+        public func setup(_ expectation: XCTestExpectation) {
+            base.setup(expectation)
         }
         
-        public func _value() throws -> Output {
-            try transform(base._value())
+        public func expectedValue() throws -> Output {
+            try transform(base.expectedValue())
         }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Map.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Map.swift
@@ -18,8 +18,6 @@ extension PublisherExpectations {
     }
 }
 
-extension PublisherExpectations.Map: InvertablePublisherExpectation where Base: InvertablePublisherExpectation { }
-
 extension PublisherExpectation {
     /// Returns a publisher expectation that transforms the value of the
     /// base expectation.

--- a/Sources/CombineExpectations/PublisherExpectations/Next.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Next.swift
@@ -34,7 +34,7 @@ extension PublisherExpectations {
             self.count = count
         }
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             if count == 0 {
                 // Such an expectation is immediately fulfilled, by essence.
                 expectation.expectedFulfillmentCount = 1
@@ -45,7 +45,7 @@ extension PublisherExpectations {
             }
         }
         
-        public func _value() throws -> [Input] {
+        public func expectedValue() throws -> [Input] {
             try recorder.expectationValue { (_, completion, remaining, consume) in
                 if remaining.count >= count {
                     consume(count)

--- a/Sources/CombineExpectations/PublisherExpectations/Next.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Next.swift
@@ -41,7 +41,7 @@ extension PublisherExpectations {
                 expectation.fulfill()
             } else {
                 expectation.expectedFulfillmentCount = count
-                recorder.fulfillOnInput(expectation)
+                recorder.fulfillOnInput(expectation, includingConsumed: false)
             }
         }
         

--- a/Sources/CombineExpectations/PublisherExpectations/Next.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Next.swift
@@ -46,10 +46,10 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws -> [Input] {
-            try recorder.expectationValue { (_, completion, remaining, consume) in
-                if remaining.count >= count {
+            try recorder.value { (_, completion, remainingElements, consume) in
+                if remainingElements.count >= count {
                     consume(count)
-                    return Array(remaining.prefix(count))
+                    return Array(remainingElements.prefix(count))
                 }
                 if case let .failure(error) = completion {
                     throw error

--- a/Sources/CombineExpectations/PublisherExpectations/Next.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Next.swift
@@ -1,6 +1,29 @@
 import XCTest
 
 extension PublisherExpectations {
+    /// A publisher expectation which waits for the recorded publisher
+    /// to emit `count` elements, or to complete.
+    ///
+    /// When waiting for this expectation, a RecordingError is thrown if the
+    /// publisher does not publish `count` elements after last waited
+    /// expectation. The publisher error is thrown if the publisher fails before
+    /// publishing `count` elements.
+    ///
+    /// Otherwise, an array of exactly `count` element is returned.
+    ///
+    /// For example:
+    ///
+    ///     // SUCCESS: no timeout, no error
+    ///     func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
+    ///         let publisher = ["foo", "bar", "baz"].publisher
+    ///         let recorder = publisher.record()
+    ///
+    ///         var elements = try wait(for: recorder.next(2), timeout: 1)
+    ///         XCTAssertEqual(elements, ["foo", "bar"])
+    ///
+    ///         elements = try wait(for: recorder.next(1), timeout: 1)
+    ///         XCTAssertEqual(elements, ["baz"])
+    ///     }
     public struct Next<Input, Failure: Error>: InvertablePublisherExpectation {
         let recorder: Recorder<Input, Failure>
         let count: Int

--- a/Sources/CombineExpectations/PublisherExpectations/Next.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Next.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+extension PublisherExpectations {
+    public struct Next<Input, Failure: Error>: InvertablePublisherExpectation {
+        let recorder: Recorder<Input, Failure>
+        let count: Int
+        
+        init(recorder: Recorder<Input, Failure>, count: Int) {
+            precondition(count >= 0, "Can't take a prefix of negative length")
+            self.recorder = recorder
+            self.count = count
+        }
+        
+        public func _setup(_ expectation: XCTestExpectation) {
+            if count == 0 {
+                // Such an expectation is immediately fulfilled, by essence.
+                expectation.expectedFulfillmentCount = 1
+                expectation.fulfill()
+            } else {
+                expectation.expectedFulfillmentCount = count
+                recorder.fulfillOnInput(expectation)
+            }
+        }
+        
+        public func _value() throws -> [Input] {
+            try recorder.expectationValue { (_, completion, remaining, consume) in
+                if remaining.count >= count {
+                    consume(count)
+                    return Array(remaining.prefix(count))
+                }
+                if case let .failure(error) = completion {
+                    throw error
+                } else {
+                    throw RecordingError.notEnoughElements
+                }
+            }
+        }
+    }
+}

--- a/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
@@ -28,7 +28,7 @@ extension PublisherExpectations {
         let recorder: Recorder<Input, Failure>
         
         public func setup(_ expectation: XCTestExpectation) {
-            recorder.fulfillOnInput(expectation)
+            recorder.fulfillOnInput(expectation, includingConsumed: false)
         }
         
         public func expectedValue() throws -> Input? {
@@ -56,7 +56,7 @@ extension PublisherExpectations {
         
         public func setup(_ expectation: XCTestExpectation) {
             expectation.isInverted = true
-            recorder.fulfillOnInput(expectation)
+            recorder.fulfillOnInput(expectation, includingConsumed: false)
         }
         
         public func expectedValue() throws {

--- a/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
@@ -27,11 +27,11 @@ extension PublisherExpectations {
     public struct NextOne<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnInput(expectation)
         }
         
-        public func _value() throws -> Input? {
+        public func expectedValue() throws -> Input? {
             try recorder.expectationValue { (_, completion, remaining, consume) in
                 if let next = remaining.first {
                     consume(1)
@@ -54,12 +54,12 @@ extension PublisherExpectations {
     public struct NextOneInverted<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             expectation.isInverted = true
             recorder.fulfillOnInput(expectation)
         }
         
-        public func _value() throws {
+        public func expectedValue() throws {
             try recorder.expectationValue { (_, completion, remaining, consume) in
                 if remaining.isEmpty == false {
                     return

--- a/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
@@ -2,27 +2,27 @@ import XCTest
 
 extension PublisherExpectations {
     /// A publisher expectation which waits for the recorded publisher to emit
-    /// `count` elements, or to complete.
+    /// one element, or to complete.
     ///
     /// When waiting for this expectation, a RecordingError is thrown if the
-    /// publisher does not publish `count` elements after last waited
-    /// expectation. The publisher error is thrown if the publisher fails before
-    /// publishing `count` elements.
+    /// publisher does not publish one element after last waited expectation.
+    /// The publisher error is thrown if the publisher fails before
+    /// publishing one element.
     ///
-    /// Otherwise, an array of exactly `count` element is returned.
+    /// Otherwise, the next published element is returned.
     ///
     /// For example:
     ///
     ///     // SUCCESS: no timeout, no error
-    ///     func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
-    ///         let publisher = ["foo", "bar", "baz"].publisher
+    ///     func testArrayOfTwoElementsPublishesElementsInOrder() throws {
+    ///         let publisher = ["foo", "bar"].publisher
     ///         let recorder = publisher.record()
     ///
-    ///         var elements = try wait(for: recorder.next(2), timeout: 1)
-    ///         XCTAssertEqual(elements, ["foo", "bar"])
+    ///         var element = try wait(for: recorder.next(), timeout: 1)
+    ///         XCTAssertEqual(element, "foo")
     ///
-    ///         elements = try wait(for: recorder.next(1), timeout: 1)
-    ///         XCTAssertEqual(elements, ["baz"])
+    ///         element = try wait(for: recorder.next(), timeout: 1)
+    ///         XCTAssertEqual(element, "bar")
     ///     }
     public struct NextOne<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
@@ -45,13 +45,43 @@ extension PublisherExpectations {
             }
         }
         
-        /// TODO
+        /// Returns an inverted publisher expectation which waits for the
+        /// recorded publisher to emit one element, or to complete.
+        ///
+        /// When waiting for this expectation, a RecordingError is thrown if the
+        /// publisher does not publish one element after last waited
+        /// expectation. The publisher error is thrown if the publisher fails
+        /// before publishing one element.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no timeout, no error
+        ///     func testPassthroughSubjectDoesNotPublishAnyElement() throws {
+        ///         let publisher = PassthroughSubject<String, Never>()
+        ///         let recorder = publisher.record()
+        ///         try wait(for: recorder.next().inverted, timeout: 1)
+        ///     }
         public var inverted: NextOneInverted<Input, Failure> {
             return NextOneInverted(recorder: recorder)
         }
     }
     
-    /// TODO
+    /// An inverted publisher expectation which waits for the recorded publisher
+    /// to emit one element, or to complete.
+    ///
+    /// When waiting for this expectation, a RecordingError is thrown if the
+    /// publisher does not publish one element after last waited expectation.
+    /// The publisher error is thrown if the publisher fails before
+    /// publishing one element.
+    ///
+    /// For example:
+    ///
+    ///     // SUCCESS: no timeout, no error
+    ///     func testPassthroughSubjectDoesNotPublishAnyElement() throws {
+    ///         let publisher = PassthroughSubject<String, Never>()
+    ///         let recorder = publisher.record()
+    ///         try wait(for: recorder.next().inverted, timeout: 1)
+    ///     }
     public struct NextOneInverted<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         

--- a/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
@@ -32,8 +32,8 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws -> Input? {
-            try recorder.expectationValue { (_, completion, remaining, consume) in
-                if let next = remaining.first {
+            try recorder.value { (_, completion, remainingElements, consume) in
+                if let next = remainingElements.first {
                     consume(1)
                     return next
                 }
@@ -51,6 +51,7 @@ extension PublisherExpectations {
         }
     }
     
+    /// TODO
     public struct NextOneInverted<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
@@ -60,8 +61,8 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws {
-            try recorder.expectationValue { (_, completion, remaining, consume) in
-                if remaining.isEmpty == false {
+            try recorder.value { (_, completion, remainingElements, consume) in
+                if remainingElements.isEmpty == false {
                     return
                 }
                 if case let .failure(error) = completion {

--- a/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
@@ -100,10 +100,5 @@ extension PublisherExpectations {
                 }
             }
         }
-        
-        /// :nodoc:
-        public var inverted: NextOne<Input, Failure> {
-            return NextOne(recorder: recorder)
-        }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
@@ -53,16 +53,16 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws -> [Input] {
-            try recorder.expectationValue { (elements, completion, remaining, consume) in
+            try recorder.value { (elements, completion, remainingElements, consume) in
                 if elements.count >= maxLength {
-                    let extraCount = max(maxLength + remaining.count - elements.count, 0)
+                    let extraCount = max(maxLength + remainingElements.count - elements.count, 0)
                     consume(extraCount)
                     return Array(elements.prefix(maxLength))
                 }
                 if case let .failure(error) = completion {
                     throw error
                 }
-                consume(remaining.count)
+                consume(remainingElements.count)
                 return elements
             }
         }

--- a/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
@@ -41,7 +41,7 @@ extension PublisherExpectations {
             self.maxLength = maxLength
         }
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             if maxLength == 0 {
                 // Such an expectation is immediately fulfilled, by essence.
                 expectation.expectedFulfillmentCount = 1
@@ -52,7 +52,7 @@ extension PublisherExpectations {
             }
         }
         
-        public func _value() throws -> [Input] {
+        public func expectedValue() throws -> [Input] {
             try recorder.expectationValue { (elements, completion, remaining, consume) in
                 if elements.count >= maxLength {
                     let extraCount = max(maxLength + remaining.count - elements.count, 0)

--- a/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
@@ -48,7 +48,7 @@ extension PublisherExpectations {
                 expectation.fulfill()
             } else {
                 expectation.expectedFulfillmentCount = maxLength
-                recorder.fulfillOnInput(expectation)
+                recorder.fulfillOnInput(expectation, includingConsumed: true)
             }
         }
         

--- a/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
@@ -41,14 +41,19 @@ extension PublisherExpectations {
         }
         
         public func _value() throws -> [Input] {
-            let (elements, completion) = recorder.elementsAndCompletion
-            if elements.count >= maxLength {
-                return Array(elements.prefix(maxLength))
+            try recorder.expectationValue { (elements, completion, remaining, consume) in
+                if elements.count >= maxLength {
+                    let result = Array(elements.prefix(maxLength))
+                    let extraCount = max(maxLength + remaining.count - elements.count, 0)
+                    consume(extraCount)
+                    return result
+                }
+                if case let .failure(error) = completion {
+                    throw error
+                }
+                consume(remaining.count)
+                return elements
             }
-            if case let .failure(error) = completion {
-                throw error
-            }
-            return elements
         }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Recording.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Recording.swift
@@ -28,11 +28,13 @@ extension PublisherExpectations {
         }
         
         public func _value() throws -> Record<Input, Failure>.Recording {
-            let (elements, completion) = recorder.elementsAndCompletion
-            if let completion = completion {
-                return Record<Input, Failure>.Recording(output: elements, completion: completion)
-            } else {
-                throw RecordingError.notCompleted
+            try recorder.expectationValue { (elements, completion, remaining, consume) in
+                if let completion = completion {
+                    consume(remaining.count)
+                    return Record<Input, Failure>.Recording(output: elements, completion: completion)
+                } else {
+                    throw RecordingError.notCompleted
+                }
             }
         }
     }

--- a/Sources/CombineExpectations/PublisherExpectations/Recording.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Recording.swift
@@ -31,9 +31,9 @@ extension PublisherExpectations {
         }
         
         public func expectedValue() throws -> Record<Input, Failure>.Recording {
-            try recorder.expectationValue { (elements, completion, remaining, consume) in
+            try recorder.value { (elements, completion, remainingElements, consume) in
                 if let completion = completion {
-                    consume(remaining.count)
+                    consume(remainingElements.count)
                     return Record<Input, Failure>.Recording(output: elements, completion: completion)
                 } else {
                     throw RecordingError.notCompleted

--- a/Sources/CombineExpectations/PublisherExpectations/Recording.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Recording.swift
@@ -2,11 +2,14 @@ import Combine
 import XCTest
 
 extension PublisherExpectations {
-    /// A publisher expectation which waits for a publisher to
-    /// complete successfully.
+    /// A publisher expectation which waits for the recorded publisher
+    /// to complete.
     ///
-    /// When waiting for this expectation, an error is thrown if the publisher
-    /// does not complete on time.
+    /// When waiting for this expectation, a RecordingError.notCompleted is
+    /// thrown if the publisher does not complete on time.
+    ///
+    /// Otherwise, a [Record.Recording](https://developer.apple.com/documentation/combine/record/recording)
+    /// is returned.
     ///
     /// For example:
     ///

--- a/Sources/CombineExpectations/PublisherExpectations/Recording.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Recording.swift
@@ -26,11 +26,11 @@ extension PublisherExpectations {
     public struct Recording<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func _setup(_ expectation: XCTestExpectation) {
+        public func setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnCompletion(expectation)
         }
         
-        public func _value() throws -> Record<Input, Failure>.Recording {
+        public func expectedValue() throws -> Record<Input, Failure>.Recording {
             try recorder.expectationValue { (elements, completion, remaining, consume) in
                 if let completion = completion {
                     consume(remaining.count)

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -347,6 +347,14 @@ extension Recorder {
         elements.map { $0.last }
     }
     
+    public func next() -> PublisherExpectations.Map<PublisherExpectations.Next<Input, Failure>, Input> {
+        return next(1).map { $0[0] }
+    }
+    
+    public func next(_ count: Int) -> PublisherExpectations.Next<Input, Failure> {
+        PublisherExpectations.Next(recorder: self, count: count)
+    }
+    
     /// Returns a publisher expectation which waits for the recorded publisher
     /// to emit `maxLength` elements, or to complete.
     ///

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -66,7 +66,7 @@ public class Recorder<Input, Failure: Error>: Subscriber {
     
     // MARK: - PublisherExpectation API
     
-    func fulfillOnInput(_ expectation: XCTestExpectation) {
+    func fulfillOnInput(_ expectation: XCTestExpectation, includingConsumed: Bool) {
         synchronized {
             switch state {
             case let .waitingForSubscription(expectations):
@@ -75,7 +75,12 @@ public class Recorder<Input, Failure: Error>: Subscriber {
                 state = .waitingForSubscription(expectations)
                 
             case let .subscribed(subscription, expectations, elements):
-                let fulfillmentCount = min(expectation.expectedFulfillmentCount, elements.count)
+                let fulfillmentCount: Int
+                if includingConsumed {
+                    fulfillmentCount = min(expectation.expectedFulfillmentCount, elements.count)
+                } else {
+                    fulfillmentCount = min(expectation.expectedFulfillmentCount, elements.count - consumedCount)
+                }
                 expectation.fulfill(count: fulfillmentCount)
                 
                 let remainingCount = expectation.expectedFulfillmentCount - fulfillmentCount

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -198,14 +198,8 @@ extension PublisherExpectations {
     /// The type of the publisher expectation returned by Recorder.elements
     public typealias Elements<Input, Failure: Error> = Map<Recording<Input, Failure>, [Input]>
     
-    /// The type of the publisher expectation returned by Recorder.first
-    public typealias First<Input, Failure: Error> = Map<Prefix<Input, Failure>, Input?>
-    
     /// The type of the publisher expectation returned by Recorder.last
     public typealias Last<Input, Failure: Error> = Map<Elements<Input, Failure>, Input?>
-    
-    /// The type of the publisher expectation returned by Recorder.next()
-    public typealias Next1<Input, Failure: Error> = Map<Next<Input, Failure>, Input>
     
     /// The type of the publisher expectation returned by Recorder.single
     public typealias Single<Input, Failure: Error> = Map<Elements<Input, Failure>, Input>
@@ -318,10 +312,10 @@ extension Recorder {
     ///     func testPassthroughSubjectDoesNotPublishAnyElement() throws {
     ///         let publisher = PassthroughSubject<String, Never>()
     ///         let recorder = publisher.record()
-    ///         _ = try wait(for: recorder.first.inverted, timeout: 1)
+    ///         try wait(for: recorder.first.inverted, timeout: 1)
     ///     }
     public var first: PublisherExpectations.First<Input, Failure> {
-        prefix(1).map { $0.first }
+        PublisherExpectations.First(recorder: self)
     }
     
     /// Returns a publisher expectation which waits for the recorded publisher
@@ -373,8 +367,8 @@ extension Recorder {
     ///         element = try wait(for: recorder.next(), timeout: 1)
     ///         XCTAssertEqual(element, "bar")
     ///     }
-    public func next() -> PublisherExpectations.Next1<Input, Failure> {
-        return next(1).map { $0[0] }
+    public func next() -> PublisherExpectations.NextOne<Input, Failure> {
+        PublisherExpectations.NextOne(recorder: self)
     }
     
     /// Returns a publisher expectation which waits for the recorded publisher

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -25,6 +25,17 @@ public class Recorder<Input, Failure: Error>: Subscriber {
         case waitingForSubscription(Expectations)
         case subscribed(Subscription, Expectations, [Input])
         case completed([Input], Subscribers.Completion<Failure>)
+        
+        var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
+            switch self {
+            case .waitingForSubscription:
+                return (elements: [], completion: nil)
+            case let .subscribed(_, _, elements):
+                return (elements: elements, completion: nil)
+            case let .completed(elements, completion):
+                return (elements: elements, completion: completion)
+            }
+        }
     }
     
     private let lock = NSLock()
@@ -33,14 +44,7 @@ public class Recorder<Input, Failure: Error>: Subscriber {
     /// The elements and completion recorded so far.
     public var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
         synchronized {
-            switch state {
-            case .waitingForSubscription:
-                return (elements: [], completion: nil)
-            case let .subscribed(_, _, elements):
-                return (elements: elements, completion: nil)
-            case let .completed(elements, completion):
-                return (elements: elements, completion: completion)
-            }
+            state.elementsAndCompletion
         }
     }
     

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -206,7 +206,7 @@ extension PublisherExpectations {
     
     /// The type of the publisher expectation returned by Recorder.next()
     public typealias Next1<Input, Failure: Error> = Map<Next<Input, Failure>, Input>
-
+    
     /// The type of the publisher expectation returned by Recorder.single
     public typealias Single<Input, Failure: Error> = Map<Elements<Input, Failure>, Input>
 }
@@ -370,7 +370,7 @@ extension Recorder {
     ///         var element = try wait(for: recorder.next(), timeout: 1)
     ///         XCTAssertEqual(element, "foo")
     ///
-    ///         var element = try wait(for: recorder.next(), timeout: 1)
+    ///         element = try wait(for: recorder.next(), timeout: 1)
     ///         XCTAssertEqual(element, "bar")
     ///     }
     public func next() -> PublisherExpectations.Next1<Input, Failure> {

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -115,19 +115,29 @@ public class Recorder<Input, Failure: Error>: Subscriber {
         }
     }
     
-    func expectationValue<T>(_ value: (
+    /// Returns a value based on the recorded state of the publisher.
+    ///
+    /// - parameter value: A function which returns the value, given the
+    ///   recorded state of the publisher.
+    /// - parameter elements: All recorded elements.
+    /// - parameter completion: The eventual publisher completion.
+    /// - parameter remainingElements: The elements that were not consumed yet.
+    /// - parameter consume: A function which consumes elements.
+    /// - parameter count: The number of consumed elements.
+    /// - returns: The value
+    func value<T>(_ value: (
         _ elements: [Input],
         _ completion: Subscribers.Completion<Failure>?,
-        _ remaining: ArraySlice<Input>,
-        _ consume: (Int) -> ()) throws -> T)
+        _ remainingElements: ArraySlice<Input>,
+        _ consume: (_ count: Int) -> ()) throws -> T)
         rethrows -> T
     {
         try synchronized {
             let (elements, completion) = state.elementsAndCompletion
-            let remaining = elements[consumedCount...]
-            return try value(elements, completion, remaining, { count in
+            let remainingElements = elements[consumedCount...]
+            return try value(elements, completion, remainingElements, { count in
                 precondition(count >= 0)
-                precondition(count <= remaining.count)
+                precondition(count <= remainingElements.count)
                 consumedCount += count
             })
         }

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -211,6 +211,34 @@ class DocumentationTests: FailureTestCase {
         } catch is MyError { }
     }
     
+    // MARK: - next()
+    
+    // SUCCESS: no timeout, no error
+    func testArrayOfTwoElementsPublishesElementsInOrder() throws {
+        let publisher = ["foo", "bar"].publisher
+        let recorder = publisher.record()
+        
+        var element = try wait(for: recorder.next(), timeout: 1)
+        XCTAssertEqual(element, "foo")
+        
+        element = try wait(for: recorder.next(), timeout: 1)
+        XCTAssertEqual(element, "bar")
+    }
+    
+    // MARK: - next(count)
+    
+    // SUCCESS: no timeout, no error
+    func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        
+        var elements = try wait(for: recorder.next(2), timeout: 1)
+        XCTAssertEqual(elements, ["foo", "bar"])
+        
+        elements = try wait(for: recorder.next(1), timeout: 1)
+        XCTAssertEqual(elements, ["baz"])
+    }
+    
     // MARK: - Prefix
     
     // SUCCESS: no timeout, no error

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -269,6 +269,39 @@ class DocumentationTests: FailureTestCase {
         } catch RecordingError.notEnoughElements { }
     }
     
+    // MARK: - next().inverted
+    
+    // SUCCESS: no timeout, no error
+    func testPassthroughSubjectDoesNotPublishAnyElement2() throws {
+        let publisher = PassthroughSubject<String, Never>()
+        let recorder = publisher.record()
+        try wait(for: recorder.next().inverted, timeout: 0.1)
+    }
+    
+    // FAIL: Fulfilled inverted expectation
+    func testInvertedNextTooEarly() throws {
+        try assertFailure("Fulfilled inverted expectation") {
+            let publisher = PassthroughSubject<String, Never>()
+            let recorder = publisher.record()
+            publisher.send("foo")
+            try wait(for: recorder.next().inverted, timeout: 0.1)
+        }
+    }
+    
+    // FAIL: Fulfilled inverted expectation
+    // FAIL: Caught error MyError
+    func testInvertedNextError() throws {
+        try assertFailure("Fulfilled inverted expectation") {
+            do {
+                let publisher = PassthroughSubject<String, MyError>()
+                let recorder = publisher.record()
+                publisher.send(completion: .failure(MyError()))
+                try wait(for: recorder.next().inverted, timeout: 0.1)
+                XCTFail("Expected error")
+            } catch is MyError { }
+        }
+    }
+    
     // MARK: - next(count)
     
     // SUCCESS: no timeout, no error
@@ -320,7 +353,7 @@ class DocumentationTests: FailureTestCase {
             XCTFail("Expected error")
         } catch RecordingError.notEnoughElements { }
     }
-
+    
     // MARK: - Prefix
     
     // SUCCESS: no timeout, no error

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -156,7 +156,7 @@ class DocumentationTests: FailureTestCase {
     func testPassthroughSubjectDoesNotPublishAnyElement() throws {
         let publisher = PassthroughSubject<String, Never>()
         let recorder = publisher.record()
-        _ = try wait(for: recorder.first.inverted, timeout: 0.1)
+        try wait(for: recorder.first.inverted, timeout: 0.1)
     }
     
     // FAIL: Fulfilled inverted expectation
@@ -165,7 +165,7 @@ class DocumentationTests: FailureTestCase {
             let publisher = PassthroughSubject<String, Never>()
             let recorder = publisher.record()
             publisher.send("foo")
-            _ = try wait(for: recorder.first.inverted, timeout: 0.1)
+            try wait(for: recorder.first.inverted, timeout: 0.1)
         }
     }
     
@@ -177,7 +177,7 @@ class DocumentationTests: FailureTestCase {
                 let publisher = PassthroughSubject<String, MyError>()
                 let recorder = publisher.record()
                 publisher.send(completion: .failure(MyError()))
-                _ = try wait(for: recorder.first.inverted, timeout: 0.1)
+                try wait(for: recorder.first.inverted, timeout: 0.1)
                 XCTFail("Expected error")
             } catch is MyError { }
         }

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -225,6 +225,38 @@ class DocumentationTests: FailureTestCase {
         XCTAssertEqual(element, "bar")
     }
     
+    // FAIL: Asynchronous wait failed
+    // FAIL: Caught error RecordingError.notEnoughElements
+    func testNextTimeout() throws {
+        try assertFailure("Asynchronous wait failed") {
+            do {
+                let publisher = PassthroughSubject<String, Never>()
+                let recorder = publisher.record()
+                _ = try wait(for: recorder.next(), timeout: 0.1)
+            } catch RecordingError.notEnoughElements { }
+        }
+    }
+    
+    // FAIL: Caught error MyError
+    func testNextError() throws {
+        do {
+            let publisher = PassthroughSubject<String, MyError>()
+            let recorder = publisher.record()
+            publisher.send(completion: .failure(MyError()))
+            _ = try wait(for: recorder.next(), timeout: 0.1)
+        } catch is MyError { }
+    }
+    
+    // FAIL: Caught error RecordingError.notEnoughElements
+    func testNextNotEnoughElementsError() throws {
+        do {
+            let publisher = PassthroughSubject<String, Never>()
+            let recorder = publisher.record()
+            publisher.send(completion: .finished)
+            _ = try wait(for: recorder.next(), timeout: 0.1)
+        } catch RecordingError.notEnoughElements { }
+    }
+    
     // MARK: - next(count)
     
     // SUCCESS: no timeout, no error
@@ -366,7 +398,7 @@ class DocumentationTests: FailureTestCase {
     }
     
     // FAIL: Caught error RecordingError.tooManyElements
-    func testSingleMoreThanOneElementError() throws {
+    func testSingleTooManyElementsError() throws {
         do {
             let publisher = PassthroughSubject<String, Never>()
             let recorder = publisher.record()
@@ -378,7 +410,7 @@ class DocumentationTests: FailureTestCase {
     }
     
     // FAIL: Caught error RecordingError.notEnoughElements
-    func testSingleNoElementsError() throws {
+    func testSingleNotEnoughElementsError() throws {
         do {
             let publisher = PassthroughSubject<String, Never>()
             let recorder = publisher.record()

--- a/Tests/CombineExpectationsTests/LateSubscriptionTest.swift
+++ b/Tests/CombineExpectationsTests/LateSubscriptionTest.swift
@@ -33,7 +33,7 @@ class LateSubscriptionTest: FailureTestCase {
             let publisher = NoSubscriptionPublisher()
             let recorder = publisher.record()
             
-            _ = try wait(for: recorder.first.inverted, timeout: 0.1)
+            try wait(for: recorder.first.inverted, timeout: 0.1)
         }
     }
     

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -387,6 +387,12 @@ class RecorderTests: XCTestCase {
             let recorder = publisher.record()
             try wait(for: recorder.next().inverted, timeout: 0.01)
         }
+        do {
+            let publisher = Timer.publish(every: 0.2, on: .main, in: .default).autoconnect()
+            let recorder = publisher.record()
+            try wait(for: recorder.next().inverted, timeout: 0.1)
+            _ = try wait(for: recorder.next(), timeout: 0.15)
+        }
     }
     
     func testNextNext() throws {
@@ -409,8 +415,8 @@ class RecorderTests: XCTestCase {
         do {
             let publisher = Timer.publish(every: 0.1, on: .main, in: .default).autoconnect()
             let recorder = publisher.record()
-            _ = try wait(for: recorder.next(), timeout: 1)
-            _ = try wait(for: recorder.next(), timeout: 1)
+            _ = try wait(for: recorder.next(), timeout: 0.15)
+            _ = try wait(for: recorder.next(), timeout: 0.15)
         }
     }
     
@@ -668,6 +674,12 @@ class RecorderTests: XCTestCase {
             publisher.send(2)
             publisher.send(3)
             try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [2, 3])
+        }
+        do {
+            let publisher = Timer.publish(every: 0.1, on: .main, in: .default).autoconnect()
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 0.25)
+            _ = try wait(for: recorder.next(2), timeout: 0.25)
         }
     }
     
@@ -1390,6 +1402,13 @@ class RecorderTests: XCTestCase {
             let publisher = Empty<Int, Never>().delay(for: 0.1, scheduler: DispatchQueue.main)
             let recorder = publisher.record()
             try wait(for: recorder.finished.inverted, timeout: 0.01)
+        }
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            try wait(for: recorder.finished.inverted, timeout: 0.01)
+            publisher.send(completion: .finished)
+            try wait(for: recorder.finished, timeout: 0.01)
         }
     }
     

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -295,6 +295,384 @@ class RecorderTests: XCTestCase {
         }
     }
     
+    // MARK: - wait(for: recorder.next())
+    
+    func testWaitForNextSync() throws {
+        do {
+            let publisher = Empty<Int, Never>()
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(), timeout: 1)
+            XCTFail("Expected RecordingError")
+        } catch RecordingError.notEnoughElements { }
+        do {
+            let publisher = (0..<1).publisher
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+        do {
+            let publisher = (0..<2).publisher
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+    }
+    
+    func testWaitForNextAsync() throws {
+        do {
+            let publisher = Empty<Int, Never>().receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(), timeout: 1)
+            XCTFail("Expected RecordingError")
+        } catch RecordingError.notEnoughElements { }
+        do {
+            let publisher = (0..<1).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+        do {
+            let publisher = (0..<2).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+    }
+    
+    func testWaitForNextFailure() throws {
+        do {
+            let publisher = Fail<Int, TestError>(error: TestError())
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(), timeout: 1)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        do {
+            let publisher = (0..<1).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+        do {
+            let publisher = (0..<2).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+    }
+    
+    func testWaitForNextFailureAsync() throws {
+        do {
+            let publisher = Fail<Int, TestError>(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(), timeout: 1)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        do {
+            let publisher = (0..<1).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+        do {
+            let publisher = (0..<2).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let element = try wait(for: recorder.next(), timeout: 1)
+            XCTAssertEqual(element, 0)
+        }
+    }
+    
+    func testNextNext() throws {
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            publisher.send(0)
+            publisher.send(1)
+            try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 0)
+            try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 1)
+        }
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            publisher.send(0)
+            try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 0)
+            publisher.send(1)
+            try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 1)
+        }
+    }
+    
+    func testFirstNext() throws {
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            publisher.send(0)
+            publisher.send(1)
+            try XCTAssertEqual(wait(for: recorder.first, timeout: 1), 0)
+            try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 1)
+            try XCTAssertEqual(wait(for: recorder.first, timeout: 1), 0)
+        }
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            publisher.send(0)
+            try XCTAssertEqual(wait(for: recorder.first, timeout: 1), 0)
+            publisher.send(1)
+            try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 1)
+            try XCTAssertEqual(wait(for: recorder.first, timeout: 1), 0)
+        }
+    }
+    
+    func testPrefixNext() throws {
+        let publisher = PassthroughSubject<Int, Never>()
+        let recorder = publisher.record()
+        publisher.send(0)
+        publisher.send(1)
+        publisher.send(2)
+        try XCTAssertEqual(wait(for: recorder.prefix(2), timeout: 1), [0, 1])
+        try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 2)
+        try XCTAssertEqual(wait(for: recorder.prefix(2), timeout: 1), [0, 1])
+        publisher.send(3)
+        publisher.send(4)
+        publisher.send(5)
+        try XCTAssertEqual(wait(for: recorder.prefix(4), timeout: 1), [0, 1, 2, 3])
+        try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 4)
+        try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 5)
+    }
+    
+    // MARK: - wait(for: recorder.next(0))
+    
+    func testWaitForNext0Sync() throws {
+        do {
+            let publisher = Empty<Int, Never>()
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        }
+        do {
+            let publisher = (0..<1).publisher
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        }
+        do {
+            let publisher = (0..<2).publisher
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        }
+    }
+    
+    func testWaitForNext0Async() throws {
+        do {
+            let publisher = Empty<Int, Never>().receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        }
+        do {
+            let publisher = (0..<1).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        }
+        do {
+            let publisher = (0..<2).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        }
+    }
+    
+    func testWaitForNext0Failure() throws {
+        do {
+            let publisher = Fail<Int, TestError>(error: TestError())
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        } catch is TestError { }
+        do {
+            let publisher = (0..<1).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        } catch is TestError { }
+        do {
+            let publisher = (0..<2).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        } catch is TestError { }
+    }
+    
+    func testWaitForNext0FailureAsync() throws {
+        do {
+            let publisher = Fail<Int, TestError>(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        } catch is TestError { }
+        do {
+            let publisher = (0..<1).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        } catch is TestError { }
+        do {
+            let publisher = (0..<2).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(0), timeout: 1)
+            XCTAssertEqual(elements, [])
+        } catch is TestError { }
+    }
+    
+    // MARK: - wait(for: recorder.next(2))
+    
+    func testWaitForNext2Sync() throws {
+        do {
+            let publisher = Empty<Int, Never>()
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected RecordingError")
+        } catch RecordingError.notEnoughElements { }
+        do {
+            let publisher = (0..<1).publisher
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected RecordingError")
+        } catch RecordingError.notEnoughElements { }
+        do {
+            let publisher = (0..<2).publisher
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+        do {
+            let publisher = (0..<3).publisher
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+    }
+    
+    func testWaitForNext2Async() throws {
+        do {
+            let publisher = Empty<Int, Never>().receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected RecordingError")
+        } catch RecordingError.notEnoughElements { }
+        do {
+            let publisher = (0..<1).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected RecordingError")
+        } catch RecordingError.notEnoughElements { }
+        do {
+            let publisher = (0..<2).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+        do {
+            let publisher = (0..<3).publisher.receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+    }
+    
+    func testWaitForNext2Failure() throws {
+        do {
+            let publisher = Fail<Int, TestError>(error: TestError())
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        do {
+            let publisher = (0..<1).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        do {
+            let publisher = (0..<2).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+        do {
+            let publisher = (0..<3).publisher.append(error: TestError())
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+    }
+    
+    func testWaitForNext2FailureAsync() throws {
+        do {
+            let publisher = Fail<Int, TestError>(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        do {
+            let publisher = (0..<1).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        do {
+            let publisher = (0..<2).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+        do {
+            let publisher = (0..<3).publisher.append(error: TestError()).receive(on: DispatchQueue.main)
+            let recorder = publisher.record()
+            let elements = try wait(for: recorder.next(2), timeout: 1)
+            XCTAssertEqual(elements, [0, 1])
+        }
+    }
+    
+    func testNext2Next2() throws {
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            publisher.send(0)
+            publisher.send(1)
+            publisher.send(2)
+            publisher.send(3)
+            try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [0, 1])
+            try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [2, 3])
+        }
+        do {
+            let publisher = PassthroughSubject<Int, Never>()
+            let recorder = publisher.record()
+            publisher.send(0)
+            publisher.send(1)
+            try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [0, 1])
+            publisher.send(2)
+            publisher.send(3)
+            try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [2, 3])
+        }
+    }
+    
+    func testPrefixNext2() throws {
+        let publisher = PassthroughSubject<Int, Never>()
+        let recorder = publisher.record()
+        publisher.send(0)
+        publisher.send(1)
+        publisher.send(2)
+        publisher.send(3)
+        try XCTAssertEqual(wait(for: recorder.prefix(2), timeout: 1), [0, 1])
+        try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [2, 3])
+        try XCTAssertEqual(wait(for: recorder.prefix(2), timeout: 1), [0, 1])
+        publisher.send(4)
+        publisher.send(5)
+        try XCTAssertEqual(wait(for: recorder.prefix(4), timeout: 1), [0, 1, 2, 3])
+        try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), [4, 5])
+    }
+    
     // MARK: - wait(for: recorder.prefix(0))
     
     func testWaitForPrefix0Sync() throws {
@@ -1221,5 +1599,4 @@ class RecorderTests: XCTestCase {
             }
         }
     }
-    
 }

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -381,6 +381,14 @@ class RecorderTests: XCTestCase {
         }
     }
     
+    func testWaitForNextInverted() throws {
+        do {
+            let publisher = Empty<Int, Never>().delay(for: 0.1, scheduler: DispatchQueue.main)
+            let recorder = publisher.record()
+            try wait(for: recorder.next().inverted, timeout: 0.01)
+        }
+    }
+    
     func testNextNext() throws {
         do {
             let publisher = PassthroughSubject<Int, Never>()
@@ -1115,8 +1123,7 @@ class RecorderTests: XCTestCase {
         do {
             let publisher = Empty<Int, Never>().delay(for: 0.1, scheduler: DispatchQueue.main)
             let recorder = publisher.record()
-            let element = try wait(for: recorder.first.inverted, timeout: 0.01)
-            XCTAssertNil(element)
+            try wait(for: recorder.first.inverted, timeout: 0.01)
         }
     }
     

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -406,6 +406,12 @@ class RecorderTests: XCTestCase {
             publisher.send(1)
             try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), 1)
         }
+        do {
+            let publisher = Timer.publish(every: 0.1, on: .main, in: .default).autoconnect()
+            let recorder = publisher.record()
+            _ = try wait(for: recorder.next(), timeout: 1)
+            _ = try wait(for: recorder.next(), timeout: 1)
+        }
     }
     
     func testFirstNext() throws {

--- a/Tests/CombineExpectationsTests/WackySubscriberTests.swift
+++ b/Tests/CombineExpectationsTests/WackySubscriberTests.swift
@@ -81,7 +81,7 @@ class WackySubscriberTests: FailureTestCase {
                 subscriber.receive(completion: .finished)
             }
         }
-        assertFailure("failed - Publisher is already completed") {
+        assertFailure("failed - Publisher recorder got unexpected completion after completion") {
             let publisher = DoubleCompletionPublisher(base: Just("foo"))
             _ = publisher.record()
         }


### PR DESCRIPTION
This pull request brings the `next()` and `next(count)` publisher expectations.

```swift
// SUCCESS: no timeout, no error
func testPublisher() throws {
    let publisher = ["foo", "bar", "baz", "qux"].publisher
    let recorder = publisher.record()
    
    try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), "foo")
    try XCTAssertEqual(wait(for: recorder.next(2), timeout: 1), ["bar", "baz"])
    try XCTAssertEqual(wait(for: recorder.next(), timeout: 1), "qux")
}
```