### PR TITLE
Add a default value to timeout parameter of waiting function

### DIFF
--- a/Sources/CombineExpectations/PublisherExpectation.swift
+++ b/Sources/CombineExpectations/PublisherExpectation.swift
@@ -48,7 +48,7 @@ extension XCTestCase {
     /// - throws: An error if the expectation fails.
     public func wait<R: PublisherExpectation>(
         for publisherExpectation: R,
-        timeout: TimeInterval,
+        timeout: TimeInterval = 1.0,
         description: String = "")
         throws -> R.Output
     {


### PR DESCRIPTION
Adds a reasonable default value we use most of the cases anyway.