### PR TITLE
Support for synchronous tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to this project will be documented in this file.
 - [0.1.0](#010)
 
 
+## Next Release
+
+- [#6](https://github.com/groue/CombineExpectations/pull/6): Support for synchronous tests
+
+**Documentation diff**:
+
+The [Usage] section shows how to use the new `get()` method in order to perform synchronous tests that do not have to wait.
+
+
 ## 0.3.0
 
 Released November 27, 2019 &bull; [diff](https://github.com/groue/CombineExpectations/compare/v0.2.0...v0.3.0)
@@ -30,3 +39,5 @@ Released November 24, 2019 &bull; [diff](https://github.com/groue/CombineExpecta
 Released November 23, 2019
 
 **Initial release**
+
+[Usage]: README.md#usage

--- a/Sources/CombineExpectations/PublisherExpectations/Finished.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Finished.swift
@@ -43,11 +43,22 @@ extension PublisherExpectations {
     public struct Finished<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func setup(_ expectation: XCTestExpectation) {
+        public func _setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnCompletion(expectation)
         }
         
-        public func expectedValue() throws {
+        /// Returns the expected output, or throws an error if the
+        /// expectation fails.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no error
+        ///     func testArrayPublisherSynchronouslyFinishesWithoutError() throws {
+        ///         let publisher = ["foo", "bar", "baz"].publisher
+        ///         let recorder = publisher.record()
+        ///         try recorder.finished.get()
+        ///     }
+        public func get() throws {
             try recorder.value { (_, completion, remainingElements, consume) in
                 guard let completion = completion else {
                     consume(remainingElements.count)

--- a/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Inverted.swift
@@ -17,13 +17,13 @@ extension PublisherExpectations {
     public struct Inverted<Base: PublisherExpectation>: PublisherExpectation {
         let base: Base
         
-        public func setup(_ expectation: XCTestExpectation) {
-            base.setup(expectation)
+        public func _setup(_ expectation: XCTestExpectation) {
+            base._setup(expectation)
             expectation.isInverted.toggle()
         }
         
-        public func expectedValue() throws -> Base.Output {
-            try base.expectedValue()
+        public func get() throws -> Base.Output {
+            try base.get()
         }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Map.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Map.swift
@@ -8,12 +8,12 @@ extension PublisherExpectations {
         let base: Base
         let transform: (Base.Output) throws -> Output
         
-        public func setup(_ expectation: XCTestExpectation) {
-            base.setup(expectation)
+        public func _setup(_ expectation: XCTestExpectation) {
+            base._setup(expectation)
         }
         
-        public func expectedValue() throws -> Output {
-            try transform(base.expectedValue())
+        public func get() throws -> Output {
+            try transform(base.get())
         }
     }
 }

--- a/Sources/CombineExpectations/PublisherExpectations/Next.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Next.swift
@@ -34,7 +34,7 @@ extension PublisherExpectations {
             self.count = count
         }
         
-        public func setup(_ expectation: XCTestExpectation) {
+        public func _setup(_ expectation: XCTestExpectation) {
             if count == 0 {
                 // Such an expectation is immediately fulfilled, by essence.
                 expectation.expectedFulfillmentCount = 1
@@ -45,7 +45,23 @@ extension PublisherExpectations {
             }
         }
         
-        public func expectedValue() throws -> [Input] {
+        /// Returns the expected output, or throws an error if the
+        /// expectation fails.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no error
+        ///     func testArrayOfThreeElementsSynchronouslyPublishesTwoThenOneElement() throws {
+        ///         let publisher = ["foo", "bar", "baz"].publisher
+        ///         let recorder = publisher.record()
+        ///
+        ///         var elements = try recorder.next(2).get()
+        ///         XCTAssertEqual(elements, ["foo", "bar"])
+        ///
+        ///         elements = try recorder.next(1).get()
+        ///         XCTAssertEqual(elements, ["baz"])
+        ///     }
+        public func get() throws -> [Input] {
             try recorder.value { (_, completion, remainingElements, consume) in
                 if remainingElements.count >= count {
                     consume(count)

--- a/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/NextOne.swift
@@ -27,11 +27,27 @@ extension PublisherExpectations {
     public struct NextOne<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func setup(_ expectation: XCTestExpectation) {
+        public func _setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnInput(expectation, includingConsumed: false)
         }
         
-        public func expectedValue() throws -> Input? {
+        /// Returns the expected output, or throws an error if the
+        /// expectation fails.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no error
+        ///     func testArrayOfTwoElementsSynchronouslyPublishesElementsInOrder() throws {
+        ///         let publisher = ["foo", "bar"].publisher
+        ///         let recorder = publisher.record()
+        ///
+        ///         var element = try recorder.next().get()
+        ///         XCTAssertEqual(element, "foo")
+        ///
+        ///         element = try recorder.next().get()
+        ///         XCTAssertEqual(element, "bar")
+        ///     }
+        public func get() throws -> Input? {
             try recorder.value { (_, completion, remainingElements, consume) in
                 if let next = remainingElements.first {
                     consume(1)
@@ -85,12 +101,12 @@ extension PublisherExpectations {
     public struct NextOneInverted<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func setup(_ expectation: XCTestExpectation) {
+        public func _setup(_ expectation: XCTestExpectation) {
             expectation.isInverted = true
             recorder.fulfillOnInput(expectation, includingConsumed: false)
         }
         
-        public func expectedValue() throws {
+        public func get() throws {
             try recorder.value { (_, completion, remainingElements, consume) in
                 if remainingElements.isEmpty == false {
                     return

--- a/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Prefix.swift
@@ -41,7 +41,7 @@ extension PublisherExpectations {
             self.maxLength = maxLength
         }
         
-        public func setup(_ expectation: XCTestExpectation) {
+        public func _setup(_ expectation: XCTestExpectation) {
             if maxLength == 0 {
                 // Such an expectation is immediately fulfilled, by essence.
                 expectation.expectedFulfillmentCount = 1
@@ -52,7 +52,19 @@ extension PublisherExpectations {
             }
         }
         
-        public func expectedValue() throws -> [Input] {
+        /// Returns the expected output, or throws an error if the
+        /// expectation fails.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no error
+        ///     func testArrayOfThreeElementsSynchronouslyPublishesTwoFirstElementsWithoutError() throws {
+        ///         let publisher = ["foo", "bar", "baz"].publisher
+        ///         let recorder = publisher.record()
+        ///         let elements = try recorder.prefix(2).get()
+        ///         XCTAssertEqual(elements, ["foo", "bar"])
+        ///     }
+        public func get() throws -> [Input] {
             try recorder.value { (elements, completion, remainingElements, consume) in
                 if elements.count >= maxLength {
                     let extraCount = max(maxLength + remainingElements.count - elements.count, 0)

--- a/Sources/CombineExpectations/PublisherExpectations/Recording.swift
+++ b/Sources/CombineExpectations/PublisherExpectations/Recording.swift
@@ -26,11 +26,26 @@ extension PublisherExpectations {
     public struct Recording<Input, Failure: Error>: PublisherExpectation {
         let recorder: Recorder<Input, Failure>
         
-        public func setup(_ expectation: XCTestExpectation) {
+        public func _setup(_ expectation: XCTestExpectation) {
             recorder.fulfillOnCompletion(expectation)
         }
         
-        public func expectedValue() throws -> Record<Input, Failure>.Recording {
+        /// Returns the expected output, or throws an error if the
+        /// expectation fails.
+        ///
+        /// For example:
+        ///
+        ///     // SUCCESS: no error
+        ///     func testArrayPublisherSynchronousRecording() throws {
+        ///         let publisher = ["foo", "bar", "baz"].publisher
+        ///         let recorder = publisher.record()
+        ///         let recording = try recorder.recording.get()
+        ///         XCTAssertEqual(recording.output, ["foo", "bar", "baz"])
+        ///         if case let .failure(error) = recording.completion {
+        ///             XCTFail("Unexpected error \(error)")
+        ///         }
+        ///     }
+        public func get() throws -> Record<Input, Failure>.Recording {
             try recorder.value { (elements, completion, remainingElements, consume) in
                 if let completion = completion {
                     consume(remainingElements.count)

--- a/Sources/CombineExpectations/Recorder.swift
+++ b/Sources/CombineExpectations/Recorder.swift
@@ -52,7 +52,7 @@ public class Recorder<Input, Failure: Error>: Subscriber {
     private var consumedCount = 0
     
     /// The elements and completion recorded so far.
-    public var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
+    var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
         synchronized {
             state.elementsAndCompletion
         }

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -33,6 +33,13 @@ class DocumentationTests: FailureTestCase {
     
     // MARK: - Elements
     
+    func testArrayPublisherSynchronouslyPublishesArrayElements() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        let elements = try recorder.elements.get()
+        XCTAssertEqual(elements, ["foo", "bar", "baz"])
+    }
+    
     // SUCCESS: no timeout, no error
     func testArrayPublisherPublishesArrayElements() throws {
         let publisher = ["foo", "bar", "baz"].publisher
@@ -40,7 +47,7 @@ class DocumentationTests: FailureTestCase {
         let elements = try wait(for: recorder.elements, timeout: 0.1)
         XCTAssertEqual(elements, ["foo", "bar", "baz"])
     }
-    
+
     // FAIL: Asynchronous wait failed
     // FAIL: Caught error RecordingError.notCompleted
     func testElementsTimeout() throws {
@@ -55,6 +62,17 @@ class DocumentationTests: FailureTestCase {
     }
     
     // FAIL: Caught error MyError
+    func testElementsSynchronousError() throws {
+        do {
+            let publisher = PassthroughSubject<String, MyError>()
+            let recorder = publisher.record()
+            publisher.send(completion: .failure(MyError()))
+            _ = try recorder.elements.get()
+            XCTFail("Expected error")
+        } catch is MyError { }
+    }
+
+    // FAIL: Caught error MyError
     func testElementsError() throws {
         do {
             let publisher = PassthroughSubject<String, MyError>()
@@ -66,6 +84,13 @@ class DocumentationTests: FailureTestCase {
     }
     
     // MARK: - Finished
+    
+    // SUCCESS: no error
+    func testArrayPublisherSynchronouslyFinishesWithoutError() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        try recorder.finished.get()
+    }
     
     // SUCCESS: no timeout, no error
     func testArrayPublisherFinishesWithoutError() throws {
@@ -156,6 +181,18 @@ class DocumentationTests: FailureTestCase {
     
     // MARK: - next()
     
+    // SUCCESS: no error
+    func testArrayOfTwoElementsSynchronouslyPublishesElementsInOrder() throws {
+        let publisher = ["foo", "bar"].publisher
+        let recorder = publisher.record()
+    
+        var element = try recorder.next().get()
+        XCTAssertEqual(element, "foo")
+    
+        element = try recorder.next().get()
+        XCTAssertEqual(element, "bar")
+    }
+    
     // SUCCESS: no timeout, no error
     func testArrayOfTwoElementsPublishesElementsInOrder() throws {
         let publisher = ["foo", "bar"].publisher
@@ -238,6 +275,18 @@ class DocumentationTests: FailureTestCase {
     
     // MARK: - next(count)
     
+    // SUCCESS: no error
+    func testArrayOfThreeElementsSynchronouslyPublishesTwoThenOneElement() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+    
+        var elements = try recorder.next(2).get()
+        XCTAssertEqual(elements, ["foo", "bar"])
+    
+        elements = try recorder.next(1).get()
+        XCTAssertEqual(elements, ["baz"])
+    }
+    
     // SUCCESS: no timeout, no error
     func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
         let publisher = ["foo", "bar", "baz"].publisher
@@ -289,6 +338,14 @@ class DocumentationTests: FailureTestCase {
     }
     
     // MARK: - Prefix
+    
+    // SUCCESS: no error
+    func testArrayOfThreeElementsSynchronouslyPublishesTwoFirstElementsWithoutError() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        let elements = try recorder.prefix(2).get()
+        XCTAssertEqual(elements, ["foo", "bar"])
+    }
     
     // SUCCESS: no timeout, no error
     func testArrayOfThreeElementsPublishesTwoFirstElementsWithoutError() throws {
@@ -360,6 +417,17 @@ class DocumentationTests: FailureTestCase {
     }
     
     // MARK: - Recording
+    
+    // SUCCESS: no error
+    func testArrayPublisherSynchronousRecording() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        let recording = try recorder.recording.get()
+        XCTAssertEqual(recording.output, ["foo", "bar", "baz"])
+        if case let .failure(error) = recording.completion {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
     
     // SUCCESS: no timeout, no error
     func testArrayPublisherRecording() throws {

--- a/Tests/CombineExpectationsTests/DocumentationTests.swift
+++ b/Tests/CombineExpectationsTests/DocumentationTests.swift
@@ -8,6 +8,16 @@ class DocumentationTests: FailureTestCase {
     
     // MARK: - Completion
     
+    // SUCCESS: no error
+    func testArrayPublisherSynchronouslyCompletesWithSuccess() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        let completion = try recorder.completion.get()
+        if case let .failure(error) = completion {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+    
     // SUCCESS: no timeout, no error
     func testArrayPublisherCompletesWithSuccess() throws {
         let publisher = ["foo", "bar", "baz"].publisher
@@ -144,6 +154,17 @@ class DocumentationTests: FailureTestCase {
     
     // MARK: - Last
     
+    // SUCCESS: no error
+    func testArrayPublisherSynchronouslyPublishesLastElementLast() throws {
+        let publisher = ["foo", "bar", "baz"].publisher
+        let recorder = publisher.record()
+        if let element = try recorder.last.get() {
+            XCTAssertEqual(element, "baz")
+        } else {
+            XCTFail("Expected one element")
+        }
+    }
+    
     // SUCCESS: no timeout, no error
     func testArrayPublisherPublishesLastElementLast() throws {
         let publisher = ["foo", "bar", "baz"].publisher
@@ -180,6 +201,18 @@ class DocumentationTests: FailureTestCase {
     }
     
     // MARK: - next()
+    
+    // SUCCESS: no error
+    func testPassthroughSubjectSynchronouslyPublishesElements() throws {
+        let publisher = PassthroughSubject<String, Never>()
+        let recorder = publisher.record()
+        
+        publisher.send("foo")
+        try XCTAssertEqual(recorder.next().get(), "foo")
+        
+        publisher.send("bar")
+        try XCTAssertEqual(recorder.next().get(), "bar")
+    }
     
     // SUCCESS: no error
     func testArrayOfTwoElementsSynchronouslyPublishesElementsInOrder() throws {
@@ -454,6 +487,14 @@ class DocumentationTests: FailureTestCase {
     }
     
     // MARK: - Single
+    
+    // SUCCESS: no error
+    func testJustSynchronouslyPublishesExactlyOneElement() throws {
+        let publisher = Just("foo")
+        let recorder = publisher.record()
+        let element = try recorder.single.get()
+        XCTAssertEqual(element, "foo")
+    }
     
     // SUCCESS: no timeout, no error
     func testJustPublishesExactlyOneElement() throws {

--- a/Tests/CombineExpectationsTests/LateSubscriptionTest.swift
+++ b/Tests/CombineExpectationsTests/LateSubscriptionTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Combine
 import Foundation
-import CombineExpectations
+@testable import CombineExpectations
 
 /// Tests for subscribers that do not create subscriptions right when they
 /// receive subscribers.

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Combine
 import Foundation
-import CombineExpectations
+@testable import CombineExpectations
 
 /// General tests for publisher expectations
 class RecorderTests: XCTestCase {


### PR DESCRIPTION
This pull request exposes and documents the synchronous `get()` expectation method, which helps writing tests that *do not have to wait*.

For example:

```swift
class PublisherTests: XCTestCase {
    // SUCCESS: no error
    func testPassthroughSubjectSynchronouslyPublishesElements() throws {
        let publisher = PassthroughSubject<String, Never>()
        let recorder = publisher.record()
        
        publisher.send("foo")
        try XCTAssertEqual(recorder.next().get(), "foo")
        
        publisher.send("bar")
        try XCTAssertEqual(recorder.next().get(), "bar")
    }
    
    // SUCCESS: no error
    func testJustSynchronouslyPublishesExactlyOneElement() throws {
        let publisher = Just("foo")
        let recorder = publisher.record()
        let element = try recorder.single.get()
        XCTAssertEqual(element, "foo")
    }
}
```
