### PR TITLE
Fix XCTFail not found issue with Xcode 12.5

### DIFF
--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -15,4 +15,7 @@ Pod::Spec.new do |s|
   
   s.frameworks = ['Combine', 'XCTest']
   s.source_files = 'Sources/CombineExpectations/**/*.swift'
+  s.pod_target_xcconfig = {
+    "ENABLE_TESTING_SEARCH_PATHS" => "YES" # Required for Xcode 12.5
+  }
 end


### PR DESCRIPTION
Resolves #14 

I am not sure if there is a workaround possible for people using SPM integration due to the limitations of `Package.swift`, but this fix at least does the trick for people using CocoaPods.

Cheers!