### PR TITLE
Support watchOS 6 or later when building with Swift 5.4 or later

### DIFF
--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
+  s.watchos.deployment_target = '6.0'
   
   s.frameworks = ['Combine', 'XCTest']
   s.source_files = 'Sources/CombineExpectations/**/*.swift'

--- a/Package.swift
+++ b/Package.swift
@@ -31,3 +31,10 @@ let package = Package(
             dependencies: ["CombineExpectations"]),
     ]
 )
+
+#if swift(>=5.4)
+  // XCTest was introduced for watchOS with Swift 5.4 and Xcode 12.5.
+  package.platforms! += [
+    .watchOS("6.0")
+  ]
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "CombineExpectations",
     platforms: [
-        .iOS("13.0"),
-        .macOS("10.15"),
-        .tvOS("13.0"),
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -35,6 +35,6 @@ let package = Package(
 #if swift(>=5.4)
   // XCTest was introduced for watchOS with Swift 5.4 and Xcode 12.5.
   package.platforms! += [
-    .watchOS("6.0")
+    .watchOS(.v6)
   ]
 #endif

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Latest release**: [version 0.8.0](https://github.com/groue/CombineExpectations/tree/v0.8.0) (May 29, 2021) • [Release Notes]
 
-**Requirements**: iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ &bull; Swift 5.1+ / Xcode 11.0+
+**Requirements**: iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ / watchOS 6.0+ &bull; Swift 5.2+ / Xcode 11.4+
 
 **Contact**: Report bugs and ask questions in [Github issues](https://github.com/groue/CombineExpectations/issues).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Latest release**: [version 0.8.0](https://github.com/groue/CombineExpectations/tree/v0.8.0) (May 29, 2021) • [Release Notes]
 
-**Requirements**: iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ / watchOS 6.0+ &bull; Swift 5.2+ / Xcode 11.4+
+**Requirements**: iOS 13+, macOS 10.15+, and tvOS 13+ require Swift 5.2+ or Xcode 11.4+. watchOS 6+ requires Swift 5.4+ or Xcode 12.5+.
 
 **Contact**: Report bugs and ask questions in [Github issues](https://github.com/groue/CombineExpectations/issues).
 


### PR DESCRIPTION
Fixes an issue similar to #14 and #15.

Without this change:
```
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:41:25: error: 'Subscription' is only available in watchOS 6.0 or newer
        case subscribed(Subscription, RecorderExpectation?, [Input])
                        ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:41:14: note: add @available attribute to enclosing case
        case subscribed(Subscription, RecorderExpectation?, [Input])
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:34:18: note: add @available attribute to enclosing enum
    private enum State {
                 ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:45:33: error: 'Subscribers' is only available in watchOS 6.0 or newer
        case completed([Input], Subscribers.Completion<Failure>)
                                ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:45:14: note: add @available attribute to enclosing case
        case completed([Input], Subscribers.Completion<Failure>)
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:34:18: note: add @available attribute to enclosing enum
    private enum State {
                 ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:47:68: error: 'Subscribers' is only available in watchOS 6.0 or newer
        var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
                                                                   ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:47:13: note: add @available attribute to enclosing property
        var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
            ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:34:18: note: add @available attribute to enclosing enum
    private enum State {
                 ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:73:64: error: 'Subscribers' is only available in watchOS 6.0 or newer
    var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
                                                               ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:73:9: note: add @available attribute to enclosing property
    var elementsAndCompletion: (elements: [Input], completion: Subscribers.Completion<Failure>?) {
        ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:15:14: note: add @available attribute to enclosing generic class
public class Recorder<Input, Failure: Error>: Subscriber {
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:169:23: error: 'Subscribers' is only available in watchOS 6.0 or newer
        _ completion: Subscribers.Completion<Failure>?,
                      ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:167:10: note: add @available attribute to enclosing instance method
    func value<T>(_ value: (
         ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:15:14: note: add @available attribute to enclosing generic class
public class Recorder<Input, Failure: Error>: Subscriber {
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:205:39: error: 'Subscription' is only available in watchOS 6.0 or newer
    public func receive(subscription: Subscription) {
                                      ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:205:17: note: add @available attribute to enclosing instance method
    public func receive(subscription: Subscription) {
                ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:15:14: note: add @available attribute to enclosing generic class
public class Recorder<Input, Failure: Error>: Subscriber {
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:217:44: error: 'Subscribers' is only available in watchOS 6.0 or newer
    public func receive(_ input: Input) -> Subscribers.Demand {
                                           ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:217:17: note: add @available attribute to enclosing instance method
    public func receive(_ input: Input) -> Subscribers.Demand {
                ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:15:14: note: add @available attribute to enclosing generic class
public class Recorder<Input, Failure: Error>: Subscriber {
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:250:37: error: 'Subscribers' is only available in watchOS 6.0 or newer
    public func receive(completion: Subscribers.Completion<Failure>) {
                                    ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:250:17: note: add @available attribute to enclosing instance method
    public func receive(completion: Subscribers.Completion<Failure>) {
                ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:15:14: note: add @available attribute to enclosing generic class
public class Recorder<Input, Failure: Error>: Subscriber {
             ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:278:89: error: 'Subscribers' is only available in watchOS 6.0 or newer
    public typealias Completion<Input, Failure: Error> = Map<Recording<Input, Failure>, Subscribers.Completion<Failure>>
                                                                                        ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:278:22: note: add @available attribute to enclosing type alias
    public typealias Completion<Input, Failure: Error> = Map<Recording<Input, Failure>, Subscribers.Completion<Failure>>
                     ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:276:1: note: add @available attribute to enclosing extension
extension PublisherExpectations {
^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:571:11: error: 'Publisher' is only available in watchOS 6.0 or newer
extension Publisher {
          ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:571:1: note: add @available attribute to enclosing extension
extension Publisher {
^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:585:9: error: 'subscribe' is only available in watchOS 6.0 or newer
        subscribe(recorder)
        ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:585:9: note: add 'if #available' version check
        subscribe(recorder)
        ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:583:17: note: add @available attribute to enclosing instance method
    public func record() -> Recorder<Output, Failure> {
                ^
/Users/caraman/Library/Developer/Xcode/DerivedData/CombineCloudKit-alqasikpclehqhgocdsspbbfvywu/SourcePackages/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:571:1: note: add @available attribute to enclosing extension
extension Publisher {
^

```

We can also use the symbolic platform versions now that the project specifies `swift-tools-version:5.2`.