### PR TITLE
Improvements for Swift 5.1, Swift 5.3, Swift 5.4, watchOS 7.4, Xcode 12.5, Xcode 13 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add 5.1 in #17.
         # TODO: Add watchOS, 5.4 and 5.5 once @groue has access to macos-11 runners.
-        swift: ['5.2', '5.3']
+        swift: ['5.1', '5.2', '5.3']
         platform: [macOS, iOS, tvOS]
     steps:
     - name: Clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ concurrency:
 jobs:
   build-test:
     name: Build & Test (Swift ${{ matrix.swift }}, ${{ matrix.platform }})
-    runs-on: macos-${{ matrix.macos || '10.15' }}
-    # TODO: Remove this once @groue has access to macos-11.
-    continue-on-error: ${{ matrix.macos == '11' }}
+    runs-on: macos-${{ matrix.macos || '11' }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,11 +25,9 @@ jobs:
           - swift: '5.3'
             platform: watchOS
         include:
-          # Swift 5.4 requires macos-11 or later.
-          - swift: '5.4'
-            macos: '11'
-          - swift: '5.5'
-            macos: '11'
+          # The macOS 11 runner no longer includes Swift 5.1.
+          - swift: '5.1'
+            macos: '10.15'
     steps:
     - name: Clone
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,25 @@ concurrency:
 jobs:
   build-test:
     name: ${{ matrix.name || 'Build & Test' }} (Swift ${{ matrix.swift }}, ${{ matrix.platform }})
-    runs-on: macos-latest
+    runs-on: macos-${{ matrix.macos || '10.15' }}
+    # TODO: Remove this once @groue has access to macos-11.
+    continue-on-error: ${{ matrix.macos == '11' }}
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add watchOS, 5.4 and 5.5 once @groue has access to macos-11 runners.
-        swift: ['5.1', '5.2', '5.3']
+        swift: ['5.1', '5.2', '5.3', '5.4', '5.5']
         platform: [macOS, iOS, tvOS]
+        include:
+          # Swift 5.4 requires macos-11 or later.
+          - swift: '5.4'
+            macos: '11'
+          - swift: '5.5'
+            macos: '11'
+          # watchOS requires Swift 5.4 or later.
+          - swift: '5.4'
+            platform: watchOS
+          - swift: '5.5'
+            platform: watchOS
     steps:
     - name: Clone
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,21 @@ jobs:
       fail-fast: false
       matrix:
         swift: ['5.1', '5.2', '5.3', '5.4', '5.5']
-        platform: [macOS, iOS, tvOS]
+        platform: [macOS, iOS, tvOS, watchOS]
+        exclude:
+          # watchOS requires Swift 5.4 or later.
+          - swift: '5.1'
+            platform: watchOS
+          - swift: '5.2'
+            platform: watchOS
+          - swift: '5.3'
+            platform: watchOS
         include:
           # Swift 5.4 requires macos-11 or later.
           - swift: '5.4'
             macos: '11'
           - swift: '5.5'
             macos: '11'
-          # watchOS requires Swift 5.4 or later.
-          - swift: '5.4'
-            platform: watchOS
-          - swift: '5.5'
-            platform: watchOS
     steps:
     - name: Clone
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-test:
-    name: ${{ matrix.name || 'Build & Test' }} (Swift ${{ matrix.swift }}, ${{ matrix.platform }})
+    name: Build & Test (Swift ${{ matrix.swift }}, ${{ matrix.platform }})
     runs-on: macos-${{ matrix.macos || '10.15' }}
     # TODO: Remove this once @groue has access to macos-11.
     continue-on-error: ${{ matrix.macos == '11' }}
@@ -35,9 +35,8 @@ jobs:
     steps:
     - name: Clone
       uses: actions/checkout@v2
-    - name: ${{ matrix.name || 'Build & Test' }}
+    - name: Build & Test
       uses: mxcl/xcodebuild@v1
       with:
         swift: ~${{ matrix.swift }}
         platform: ${{ matrix.platform }}
-        action: ${{ matrix.action }}

--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
-  s.watchos.deployment_target = '6.0'
+  s.watchos.deployment_target = '7.4'
 
   s.frameworks = ['Combine', 'XCTest']
   s.source_files = 'Sources/CombineExpectations/**/*.swift'

--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author   = { 'Gwendal Roué' => 'gr@pierlis.com' }
   s.source   = { :git => 'https://github.com/groue/CombineExpectations.git', :tag => "v#{s.version}" }
 
-  s.swift_versions = ['5.2', '5.3', '5.4']
+  s.swift_versions = ['5.1', '5.2', '5.3', '5.4']
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'

--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -1,19 +1,19 @@
 Pod::Spec.new do |s|
   s.name     = 'CombineExpectations'
   s.version  = '0.9.0'
-  
+
   s.license  = { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A set of extensions for SQLite, GRDB.swift, and Combine'
   s.homepage = 'https://github.com/groue/CombineExpectations'
   s.author   = { 'Gwendal Roué' => 'gr@pierlis.com' }
   s.source   = { :git => 'https://github.com/groue/CombineExpectations.git', :tag => "v#{s.version}" }
-  
+
   s.swift_versions = ['5.2', '5.3', '5.4']
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
   s.watchos.deployment_target = '6.0'
-  
+
   s.frameworks = ['Combine', 'XCTest']
   s.source_files = 'Sources/CombineExpectations/**/*.swift'
   s.pod_target_xcconfig = {

--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -1,19 +1,19 @@
 Pod::Spec.new do |s|
   s.name     = 'CombineExpectations'
   s.version  = '0.9.0'
-
+  
   s.license  = { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A set of extensions for SQLite, GRDB.swift, and Combine'
   s.homepage = 'https://github.com/groue/CombineExpectations'
   s.author   = { 'Gwendal Roué' => 'gr@pierlis.com' }
   s.source   = { :git => 'https://github.com/groue/CombineExpectations.git', :tag => "v#{s.version}" }
-
+  
   s.swift_versions = ['5.1', '5.2', '5.3', '5.4']
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
   s.watchos.deployment_target = '7.4'
-
+  
   s.frameworks = ['Combine', 'XCTest']
   s.source_files = 'Sources/CombineExpectations/**/*.swift'
   s.pod_target_xcconfig = {

--- a/CombineExpectations.podspec
+++ b/CombineExpectations.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author   = { 'Gwendal Roué' => 'gr@pierlis.com' }
   s.source   = { :git => 'https://github.com/groue/CombineExpectations.git', :tag => "v#{s.version}" }
   
-  s.swift_versions = ['5.2']
+  s.swift_versions = ['5.2', '5.3', '5.4']
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,8 @@ let package = Package(
 )
 
 #if swift(>=5.4)
-  // XCTest was introduced for watchOS with Swift 5.4 and Xcode 12.5.
+  // XCTest was introduced for watchOS with Swift 5.4, Xcode 12.5, and watchOS 7.4.
   package.platforms! += [
-    .watchOS(.v6)
+    .watchOS("7.4")
   ]
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,6 @@ let package = Package(
             name: "CombineExpectations",
             targets: ["CombineExpectations"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "CombineExpectations",
-            dependencies: []),
+            dependencies: [],
+            linkerSettings: [.linkedFramework("XCTest")]),
         .testTarget(
             name: "CombineExpectationsTests",
             dependencies: ["CombineExpectations"]),

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Latest release**: [version 0.9.0](https://github.com/groue/CombineExpectations/tree/v0.9.0) (June 7, 2021) • [Release Notes]
 
-**Requirements**: iOS 13+, macOS 10.15+, and tvOS 13+ require Swift 5.2+ or Xcode 11.3+. watchOS 7.4+ requires Swift 5.4+ or Xcode 12.5+.
+**Requirements**: iOS 13+, macOS 10.15+, and tvOS 13+ require Swift 5.1+ or Xcode 11+. watchOS 7.4+ requires Swift 5.4+ or Xcode 12.5+.
 
 **Contact**: Report bugs and ask questions in [Github issues](https://github.com/groue/CombineExpectations/issues).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Latest release**: [version 0.9.0](https://github.com/groue/CombineExpectations/tree/v0.9.0) (June 7, 2021) • [Release Notes]
 
-**Requirements**: iOS 13+, macOS 10.15+, and tvOS 13+ require Swift 5.2+ or Xcode 11.4+. watchOS 6+ requires Swift 5.4+ or Xcode 12.5+.
+**Requirements**: iOS 13+, macOS 10.15+, and tvOS 13+ require Swift 5.2+ or Xcode 11.3+. watchOS 7.4+ requires Swift 5.4+ or Xcode 12.5+.
 
 **Contact**: Report bugs and ask questions in [Github issues](https://github.com/groue/CombineExpectations/issues).
 
@@ -34,13 +34,13 @@ class PublisherTests: XCTestCase {
     func testElements() throws {
         // 1. Create a publisher
         let publisher = ...
-        
+
         // 2. Start recording the publisher
         let recorder = publisher.record()
-        
+
         // 3. Wait for a publisher expectation
         let elements = try wait(for: recorder.elements, timeout: ..., description: "Elements")
-        
+
         // 4. Test the result of the expectation
         XCTAssertEqual(elements, ["Hello", "World!"])
     }
@@ -60,13 +60,13 @@ class PublisherTests: XCTestCase {
     func testPublisher() throws {
         let publisher = ...
         let recorder = publisher.record()
-        
+
         // Wait for first element
         _ = try wait(for: recorder.next(), timeout: ...)
-        
+
         // Wait for second element
         _ = try wait(for: recorder.next(), timeout: ...)
-        
+
         // Wait for successful completion
         try wait(for: recorder.finished, timeout: ...)
     }
@@ -80,13 +80,13 @@ class PublisherTests: XCTestCase {
     func testSynchronousPublisher() throws {
         // 1. Create a publisher
         let publisher = ...
-        
+
         // 2. Start recording the publisher
         let recorder = publisher.record()
-        
+
         // 3. Grab the expected result
         let elements = try recorder.elements.get()
-        
+
         // 4. Test the result of the expectation
         XCTAssertEqual(elements, ["Hello", "World!"])
     }
@@ -101,10 +101,10 @@ class PublisherTests: XCTestCase {
     func testPassthroughSubjectSynchronouslyPublishesElements() throws {
         let publisher = PassthroughSubject<String, Never>()
         let recorder = publisher.record()
-        
+
         publisher.send("foo")
         try XCTAssertEqual(recorder.next().get(), "foo")
-        
+
         publisher.send("bar")
         try XCTAssertEqual(recorder.next().get(), "bar")
     }
@@ -118,7 +118,7 @@ Add a dependency for CombineExpectations to your [Swift Package](https://swift.o
 
 ```diff
  import PackageDescription
- 
+
  let package = Package(
      dependencies: [
 +        .package(url: "https://github.com/groue/CombineExpectations.git", ...)
@@ -267,7 +267,7 @@ func testElementsTimeout() throws {
     let recorder = publisher.record()
     let elements = try wait(for: recorder.elements, timeout: ...)
 }
-    
+
 // FAIL: Caught error MyError
 func testElementsError() throws {
     let publisher = PassthroughSubject<String, MyError>()
@@ -318,7 +318,7 @@ func testFinishedTimeout() throws {
     let recorder = publisher.record()
     try wait(for: recorder.finished, timeout: ...)
 }
-    
+
 // FAIL: Caught error MyError
 func testFinishedError() throws {
     let publisher = PassthroughSubject<String, MyError>()
@@ -407,7 +407,7 @@ func testLastTimeout() throws {
     let recorder = publisher.record()
     let element = try wait(for: recorder.last, timeout: ...)
 }
-    
+
 // FAIL: Caught error MyError
 func testLastError() throws {
     let publisher = PassthroughSubject<String, MyError>()
@@ -439,10 +439,10 @@ Example:
 func testArrayOfTwoElementsPublishesElementsInOrder() throws {
     let publisher = ["foo", "bar"].publisher
     let recorder = publisher.record()
-    
+
     var element = try wait(for: recorder.next(), timeout: ...)
     XCTAssertEqual(element, "foo")
-    
+
     element = try wait(for: recorder.next(), timeout: ...)
     XCTAssertEqual(element, "bar")
 }
@@ -451,10 +451,10 @@ func testArrayOfTwoElementsPublishesElementsInOrder() throws {
 func testArrayOfTwoElementsSynchronouslyPublishesElementsInOrder() throws {
     let publisher = ["foo", "bar"].publisher
     let recorder = publisher.record()
-    
+
     var element = try recorder.next().get()
     XCTAssertEqual(element, "foo")
-    
+
     element = try recorder.next().get()
     XCTAssertEqual(element, "bar")
 }
@@ -546,10 +546,10 @@ Example:
 func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
     let publisher = ["foo", "bar", "baz"].publisher
     let recorder = publisher.record()
-    
+
     var elements = try wait(for: recorder.next(2), timeout: ...)
     XCTAssertEqual(elements, ["foo", "bar"])
-    
+
     elements = try wait(for: recorder.next(1), timeout: ...)
     XCTAssertEqual(elements, ["baz"])
 }
@@ -558,10 +558,10 @@ func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
 func testArrayOfThreeElementsSynchronouslyPublishesTwoThenOneElement() throws {
     let publisher = ["foo", "bar", "baz"].publisher
     let recorder = publisher.record()
-    
+
     var elements = try recorder.next(2).get()
     XCTAssertEqual(elements, ["foo", "bar"])
-    
+
     elements = try recorder.next(1).get()
     XCTAssertEqual(elements, ["baz"])
 }
@@ -645,7 +645,7 @@ func testPrefixTimeout() throws {
     publisher.send("foo")
     let elements = try wait(for: recorder.prefix(2), timeout: ...)
 }
-    
+
 // FAIL: Caught error MyError
 func testPrefixError() throws {
     let publisher = PassthroughSubject<String, MyError>()
@@ -675,7 +675,7 @@ func testPassthroughSubjectPublishesNoMoreThanSentValues() throws {
 <details>
     <summary>Examples of failing tests</summary>
 
-```swift   
+```swift
 // FAIL: Fulfilled inverted expectation
 func testInvertedPrefixTooEarly() throws {
     let publisher = PassthroughSubject<String, Never>()
@@ -685,7 +685,7 @@ func testInvertedPrefixTooEarly() throws {
     publisher.send("baz")
     let elements = try wait(for: recorder.prefix(3).inverted, timeout: ...)
 }
-    
+
 // FAIL: Fulfilled inverted expectation
 // FAIL: Caught error MyError
 func testInvertedPrefixError() throws {
@@ -797,7 +797,7 @@ func testSingleTimeout() throws {
     let recorder = publisher.record()
     let element = try wait(for: recorder.single, timeout: ...)
 }
-    
+
 // FAIL: Caught error MyError
 func testSingleError() throws {
     let publisher = PassthroughSubject<String, MyError>()
@@ -805,7 +805,7 @@ func testSingleError() throws {
     publisher.send(completion: .failure(MyError()))
     let element = try wait(for: recorder.single, timeout: ...)
 }
-    
+
 // FAIL: Caught error RecordingError.tooManyElements
 func testSingleTooManyElementsError() throws {
     let publisher = PassthroughSubject<String, Never>()
@@ -815,7 +815,7 @@ func testSingleTooManyElementsError() throws {
     publisher.send(completion: .finished)
     let element = try wait(for: recorder.single, timeout: ...)
 }
-    
+
 // FAIL: Caught error RecordingError.notEnoughElements
 func testSingleNotEnoughElementsError() throws {
     let publisher = PassthroughSubject<String, Never>()

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ class PublisherTests: XCTestCase {
     func testElements() throws {
         // 1. Create a publisher
         let publisher = ...
-
+        
         // 2. Start recording the publisher
         let recorder = publisher.record()
-
+        
         // 3. Wait for a publisher expectation
         let elements = try wait(for: recorder.elements, timeout: ..., description: "Elements")
-
+        
         // 4. Test the result of the expectation
         XCTAssertEqual(elements, ["Hello", "World!"])
     }
@@ -60,13 +60,13 @@ class PublisherTests: XCTestCase {
     func testPublisher() throws {
         let publisher = ...
         let recorder = publisher.record()
-
+        
         // Wait for first element
         _ = try wait(for: recorder.next(), timeout: ...)
-
+        
         // Wait for second element
         _ = try wait(for: recorder.next(), timeout: ...)
-
+        
         // Wait for successful completion
         try wait(for: recorder.finished, timeout: ...)
     }
@@ -80,13 +80,13 @@ class PublisherTests: XCTestCase {
     func testSynchronousPublisher() throws {
         // 1. Create a publisher
         let publisher = ...
-
+        
         // 2. Start recording the publisher
         let recorder = publisher.record()
-
+        
         // 3. Grab the expected result
         let elements = try recorder.elements.get()
-
+        
         // 4. Test the result of the expectation
         XCTAssertEqual(elements, ["Hello", "World!"])
     }
@@ -101,10 +101,10 @@ class PublisherTests: XCTestCase {
     func testPassthroughSubjectSynchronouslyPublishesElements() throws {
         let publisher = PassthroughSubject<String, Never>()
         let recorder = publisher.record()
-
+        
         publisher.send("foo")
         try XCTAssertEqual(recorder.next().get(), "foo")
-
+        
         publisher.send("bar")
         try XCTAssertEqual(recorder.next().get(), "bar")
     }
@@ -118,7 +118,7 @@ Add a dependency for CombineExpectations to your [Swift Package](https://swift.o
 
 ```diff
  import PackageDescription
-
+ 
  let package = Package(
      dependencies: [
 +        .package(url: "https://github.com/groue/CombineExpectations.git", ...)
@@ -439,10 +439,10 @@ Example:
 func testArrayOfTwoElementsPublishesElementsInOrder() throws {
     let publisher = ["foo", "bar"].publisher
     let recorder = publisher.record()
-
+    
     var element = try wait(for: recorder.next(), timeout: ...)
     XCTAssertEqual(element, "foo")
-
+    
     element = try wait(for: recorder.next(), timeout: ...)
     XCTAssertEqual(element, "bar")
 }
@@ -451,10 +451,10 @@ func testArrayOfTwoElementsPublishesElementsInOrder() throws {
 func testArrayOfTwoElementsSynchronouslyPublishesElementsInOrder() throws {
     let publisher = ["foo", "bar"].publisher
     let recorder = publisher.record()
-
+    
     var element = try recorder.next().get()
     XCTAssertEqual(element, "foo")
-
+    
     element = try recorder.next().get()
     XCTAssertEqual(element, "bar")
 }
@@ -546,10 +546,10 @@ Example:
 func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
     let publisher = ["foo", "bar", "baz"].publisher
     let recorder = publisher.record()
-
+    
     var elements = try wait(for: recorder.next(2), timeout: ...)
     XCTAssertEqual(elements, ["foo", "bar"])
-
+    
     elements = try wait(for: recorder.next(1), timeout: ...)
     XCTAssertEqual(elements, ["baz"])
 }
@@ -558,10 +558,10 @@ func testArrayOfThreeElementsPublishesTwoThenOneElement() throws {
 func testArrayOfThreeElementsSynchronouslyPublishesTwoThenOneElement() throws {
     let publisher = ["foo", "bar", "baz"].publisher
     let recorder = publisher.record()
-
+    
     var elements = try recorder.next(2).get()
     XCTAssertEqual(elements, ["foo", "bar"])
-
+    
     elements = try recorder.next(1).get()
     XCTAssertEqual(elements, ["baz"])
 }

--- a/Tests/CombineExpectationsTests/RecorderTests.swift
+++ b/Tests/CombineExpectationsTests/RecorderTests.swift
@@ -48,7 +48,7 @@ class RecorderTests: XCTestCase {
         do {
             let publisher = Timer.publish(every: 0.01, on: .main, in: .common).autoconnect()
             let recorder = publisher.record()
-            let dates = try wait(for: recorder.availableElements, timeout: 0.1)
+            let dates = try wait(for: recorder.availableElements, timeout: 1)
             XCTAssertTrue(dates.count > 2)
             XCTAssertEqual(dates.sorted(), dates)
         }
@@ -439,7 +439,7 @@ class RecorderTests: XCTestCase {
             let publisher = Timer.publish(every: 0.2, on: .main, in: .default).autoconnect()
             let recorder = publisher.record()
             try wait(for: recorder.next().inverted, timeout: 0.1)
-            _ = try wait(for: recorder.next(), timeout: 0.15)
+            _ = try wait(for: recorder.next(), timeout: 1)
         }
     }
     
@@ -463,8 +463,8 @@ class RecorderTests: XCTestCase {
         do {
             let publisher = Timer.publish(every: 0.1, on: .main, in: .default).autoconnect()
             let recorder = publisher.record()
-            _ = try wait(for: recorder.next(), timeout: 0.15)
-            _ = try wait(for: recorder.next(), timeout: 0.15)
+            _ = try wait(for: recorder.next(), timeout: 1)
+            _ = try wait(for: recorder.next(), timeout: 1)
         }
     }
     
@@ -705,8 +705,8 @@ class RecorderTests: XCTestCase {
         do {
             let publisher = Timer.publish(every: 0.1, on: .main, in: .default).autoconnect()
             let recorder = publisher.record()
-            _ = try wait(for: recorder.next(2), timeout: 0.25)
-            _ = try wait(for: recorder.next(2), timeout: 0.25)
+            _ = try wait(for: recorder.next(2), timeout: 1)
+            _ = try wait(for: recorder.next(2), timeout: 1)
         }
     }
     


### PR DESCRIPTION
Fixes:
```
/Users/runner/work/CombineCloudKit/CombineCloudKit/.build/checkouts/CombineExpectations/Sources/CombineExpectations/Recorder.swift:211:17: error: cannot find 'XCTFail' in scope
529
                  XCTFail("Publisher recorder is already subscribed")
530
                  ^~~~~~~
```

https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes
> Xcode no longer passes testing search paths to all targets.
>
> With this change, Swift package library targets (but not test targets) which import XCTest or StoreKitTest must now explicitly reference those frameworks in the package manifest using linker settings:
> `linkerSettings: [.linkedFramework("XCTest")]`
>
> This update doesn’t apply to test targets, which can still import test frameworks by default without any explicit mention in linker settings. (75061901)